### PR TITLE
Add automatic HTML generation

### DIFF
--- a/.github/workflows/add_article_decor.py
+++ b/.github/workflows/add_article_decor.py
@@ -10,7 +10,7 @@ html files inside the pages directory and its subdirectories.
 
 ZERO_DEPTH_OFFSET = -3
 
-with open("./.github/workflows/article-decor.txt") as file:
+with open("article-decor.txt") as file:
     DECORATIONS = [line for line in file.read().split("\n") if line != ""]
 
 def get_file_depth(path: str) -> int:
@@ -31,16 +31,34 @@ def get_resource_path_prepend(path: str) -> str:
     return "../" * depth
 
 
-def add_stuff(fp: str):
+def add_stuff(path: str, html: str) -> str:
     """
-    Adds missing tags for external resources to a given file.
+    Adds missing tags for head and external resources to the HTML string and returns the result.
     """
-    with open(fp, encoding="utf8") as f:
-        print("\n" + f.name)
-        orig_contents = f.read()
+
+    # format tags
+    resource_path_prepend = get_resource_path_prepend(path)
+    formatted_tag_list = []
+    for tag in DECORATIONS:
+        tag = re.sub(r'"', r"'", tag)
+        tag = re.sub(r"(href=')", r"\1"+resource_path_prepend, tag)     # css href
+        tag = re.sub(r"(src=')", r"\1"+resource_path_prepend, tag)      # js src
+        formatted_tag_list.append(tag)
+    formatted_tags = "\n".join(formatted_tag_list)
+
+    # add wrap body content with body tags, prepend head, etc
+    title = re.split(r"[\\/]", path)[-1].replace(".html", "").replace("-", " ") + " (Rain World Modding)"
+    contents = f"<!doctype html>\n<html lang='en'>\n<head>\n{formatted_tags}\n" + \
+                    "<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>\n" + \
+                    f"<title>{title}</title>\n</head>\n<body>\n" + \
+                    html + \
+                    "\n</body>\n</html>\n"
+
+
+    """
     # replace all double quotes inside the html head tags with single quotes
-    contents = re.sub(r'(<head>.*)"([^"]*)"(.*</head>)', r"\1'\2'\3", orig_contents, flags=re.DOTALL)
-    resource_path_prepend = get_resource_path_prepend(fp)
+    contents = re.sub(r'(<head>.*)"([^"]*)"(.*</head>)', r"\1'\2'\3", contents, flags=re.DOTALL)
+    resource_path_prepend = get_resource_path_prepend(path)
     
     for tag in DECORATIONS:
         # format tag string
@@ -48,31 +66,9 @@ def add_stuff(fp: str):
         tag = re.sub(r"(href=')", r"\1"+resource_path_prepend, tag)     # css href
         tag = re.sub(r"(src=')", r"\1"+resource_path_prepend, tag)      # js src
 
-        print(tag)
-        print(tag in contents)
-
         if tag not in contents:
             # insert new tag after <head> open tag
             contents = re.sub(r"(<head>)", r"\1"+"\n"+tag, contents)
-            print(f"new tag : {tag}")
-
-    if orig_contents != contents:
-        # save new contents if changed
-        with open(fp, "w", encoding="utf8") as f:
-            f.write(contents)
-
-
-def iterate_dir(dirname: str):
     """
-    Iterates through a directory for article html files. Calls modifying functions.
-    """
-    for root, _dirs, files in os.walk(dirname):
-        for f in files:
-            if f.endswith(".html"):
-                add_stuff(os.path.join(root, f))
-            
-            
 
-if __name__ == "__main__":
-    pages_path = "./pages"
-    iterate_dir(pages_path)
+    return contents

--- a/.github/workflows/add_article_decor.py
+++ b/.github/workflows/add_article_decor.py
@@ -8,7 +8,7 @@ html files inside the pages directory and its subdirectories.
 """
 
 
-ZERO_DEPTH_OFFSET = -3
+ZERO_DEPTH_OFFSET = -2
 
 with open("article-decor.txt") as file:
     DECORATIONS = [line for line in file.read().split("\n") if line != ""]

--- a/.github/workflows/html_converter.py
+++ b/.github/workflows/html_converter.py
@@ -1,0 +1,75 @@
+from bs4 import UnicodeDammit
+import hashlib
+import mistune
+import os
+from typing import Tuple
+import chardet
+
+import add_article_decor
+
+"""
+Generates HTML pages from markdown files in the pages dir and its subdirs
+"""
+
+os.chdir("../..")
+ENCODING = "utf8"
+
+def html_from_md_file(fp: str) -> str:
+    """
+    Uses mistune lib to convert md to html
+    """
+    with open(fp, "rb") as file:
+        html = mistune.html(UnicodeDammit(file.read()).unicode_markup)
+    return html
+
+
+def page_changed(fp: str, new_content: str) -> Tuple[bool, str, str]:
+    """
+    Compares hash of html file content to new file content.
+    Returns:
+        bool: whether change
+        str: new content (formatted)
+        str: encoding code
+    """
+    # read binary of existing html and use it to get probable encoding
+    with open(fp, "rb") as file:
+        file_bytes = file.read()
+    orig_encoding = chardet.detect(file_bytes)["encoding"]
+
+    # read existing html using the above encoding and generate a hash
+    with open(fp, encoding=orig_encoding) as file:
+        file_content = UnicodeDammit(file.read()).unicode_markup
+    old_hash = hashlib.sha256(file_content.encode(orig_encoding)).hexdigest()
+
+    # generate hash from new html
+    formatted_new_content = UnicodeDammit(new_content).unicode_markup
+    new_hash = hashlib.sha256(formatted_new_content.encode(orig_encoding)).hexdigest()
+
+    print(old_hash, new_hash)
+    return old_hash != new_hash, formatted_new_content, orig_encoding
+
+
+def iterate_dir(dirname: str):
+    """
+    Iterates through a directory for md files and then calls relevant methods.
+    """
+    for root, _dirs, files in os.walk(dirname):
+        for file_name in files:
+            if file_name.endswith(".md"):
+                html_file_name = file_name[:-2] + "html"
+                html_fp = os.path.join(root, html_file_name)
+
+                # get the html equivalent content from the file path to a markdown page
+                html_out = html_from_md_file(os.path.join(root, file_name))
+                html_out = add_article_decor.add_stuff(html_fp, html_out)               
+
+                _page_changed, html_out, encoding = page_changed(html_fp, html_out)
+                if html_file_name not in files or _page_changed:
+                    print(f"writing to {html_fp}")
+                    with open(html_fp, "w+", encoding=encoding) as file:
+                        file.write(html_out)
+
+
+if __name__ == "__main__":
+    print("running html converter")
+    iterate_dir("pages")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           python3 -m pip install mistune==2.0.0a6
           python3 -m pip install beautifulsoup4
-          python3 ./.github/workflows/html_converter.py
+          python3 ./html_converter.py
           
       - name: commit changes
         uses: EndBug/add-and-commit@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
-# Custom workflow for adding appropriate resource links for new article html pages
+# Custom workflow for the Rain World modding wiki update project
 
-name: resource-check
+name: wiki-workflow
 
 on: [push, workflow_dispatch]
 
@@ -9,10 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        
-      - name: check for links
-        working-directory: .
-        run: python3 ./.github/workflows/add_article_decor.py
+
+      - name: generate html pages
+        working-directory: ./.github/workflows
+        run: |
+          python3 -m pip install mistune==2.0.0a6
+          python3 -m pip install beautifulsoup4
+          python3 ./.github/workflows/html_converter.py
           
       - name: commit changes
         uses: EndBug/add-and-commit@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
       - name: commit changes
         uses: EndBug/add-and-commit@v6
         with:
-          message: 'Automatically added resource links (GitHub Action)'
+          message: 'Automatically generated HTML (GitHub Action)'
           add: pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs
 .vscode
+__pycache__

--- a/contributing.md
+++ b/contributing.md
@@ -17,7 +17,7 @@ When adding to or editing the content of this repository, please follow the list
 4. Find an appropriate category for your article, or if one does not exist create a new one.
     - To create a new category, add the name of the category to `pages/pages.json` as a new key. Add a list as the corresponding value. Create a new folder in the `pages` folder and make its name the name of the category but all lowercase and each space with "`-`" (a hyphen).
 
-5. Save your article's .md file to the category's folder, avoiding using spaces in the file name. Export an HTML (without styling) of this article (this is an option in Typora under File>Export) and place the .html file in the same place with the same name as the .md file.
+5. Save your article's .md file to the category's folder, avoiding using spaces in the file name. You should no longer export HTML - GitHub will handle this for you :D
 
 6. Open `pages/pages.json` in a text editor and add the exact name of your .md file (minus the md file extension) to the list corresponding to the chosen category. Here is an example extract from the json file - note the usage of double quotes and commas:
 

--- a/pages/creating-mods/BepInPlugins.html
+++ b/pages/creating-mods/BepInPlugins.html
@@ -1,44 +1,38 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>BepInPlugins</title></head>
-<body><h1>BepInPlugins</h1>
-<p>BepInPlugins are a kind of game mod native to <a href='https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html'>BepInEx</a>. They are not compatible with Partiality. They should be placed in <code>Rain World/BepInEx/plugins</code>. </p>
+<title>BepInPlugins (Rain World Modding)</title>
+</head>
+<body>
+<h1>BepInPlugins</h1>
+<p>BepInPlugins are a kind of game mod native to <a href="https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html">BepInEx</a>. They are not compatible with Partiality. They should be placed in <code>Rain World/BepInEx/plugins</code>.</p>
 <hr />
 <h2>Creating a BepInPlugin</h2>
 <h3>Prerequisites</h3>
 <ul>
-<li><p>A solid understanding of some key concepts including C# syntax and environment, and Unity (good but not necessary)</p>
-</li>
-<li><p>Rain World with RW BepInEx set up - see <a href='https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html'>here</a>.</p>
-</li>
-<li><p>Some kind of .NET programming environment, probably Visual Studio if you&#39;re on Windows, or Visual Studio Code for Linux/Mac. The guide below will assume you&#39;re already comfortable with the first prerequisite and your editor and environment of choice. </p>
-<ul>
+<li>A solid understanding of some key concepts including C# syntax and environment, and Unity (good but not necessary)</li>
+<li>Rain World with RW BepInEx set up - see <a href="https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html">here</a>.</li>
+<li>Some kind of .NET programming environment, probably Visual Studio if you're on Windows, or Visual Studio Code for Linux/Mac. The guide below will assume you're already comfortable with the first prerequisite and your editor and environment of choice.<ul>
 <li>The .NET Development pack for Visual Studio (or similar for other environments - you need to be able to use .NET Framework 3.5)</li>
-
 </ul>
 </li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Step 1 - The project</h3>
-<p>Create a new C# .NET Framework 3.5 Class Library project in your IDE. You will then need to <a href='https://docs.microsoft.com/en-us/visualstudio/ide/how-to-add-or-remove-references-by-using-the-reference-manager?view=vs-2019'>add some references</a>. </p>
-<p>It&#39;s recommended that you copy the files you need to reference to a safe location outside of the Rain World root directory before referencing them. Assuming you already have BepInEx installed and ready to go, the files (relative to the Rain World root directory) you should reference are:</p>
+<p>Create a new C# .NET Framework 3.5 Class Library project in your IDE. You will then need to <a href="https://docs.microsoft.com/en-us/visualstudio/ide/how-to-add-or-remove-references-by-using-the-reference-manager?view=vs-2019">add some references</a>.</p>
+<p>It's recommended that you copy the files you need to reference to a safe location outside of the Rain World root directory before referencing them. Assuming you already have BepInEx installed and ready to go, the files (relative to the Rain World root directory) you should reference are:</p>
 <ul>
 <li><code>BepInEx/plugins/PartialityWrapper/HOOKS-Assembly-CSharp.dll</code></li>
 <li><code>BepInEx/core/BepInEx.dll</code></li>
 <li><code>RainWorld_Data/Managed/UnityEngine.dll</code></li>
-<li><code>RainWorld_Data/Managed/Assembly-CSharp.dll</code> - <em>note: you will need to modify this before accessing private members; see the section &quot;Replacement of Publicity Stunt&quot; on the <a href='https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html'>BepInEx page</a>.</em></li>
-
+<li><code>RainWorld_Data/Managed/Assembly-CSharp.dll</code> - <em>note: you will need to modify this before accessing private members; see the section &quot;Replacement of Publicity Stunt&quot; on the <a href="https://rain-world-modding.github.io/rain-world-modding/pages/using-mods/BepInEx.html">BepInEx page</a>.</em></li>
 </ul>
-<p>&nbsp;</p>
 <h3>Step 2 - The BepInPlugin class</h3>
 <p>In a your new C# file, make a public class that has the <code>BepInEx.BepInPlugin</code> attribute and inherits from <code>BepInEx.BaseUnityPlugin</code> . The <code>BaseUnityPlugin</code> class inherits from <code>MonoBehaviour</code>, so you can use standard Unity script methods such as <code>OnEnable</code> and <code>OnDisable</code> in this class.</p>
-<pre><code class='language-c#' lang='c#'>using BepInEx;
+<pre><code class="language-c#">using BepInEx;
 
 namespace SomeMod
 {
@@ -48,42 +42,40 @@ namespace SomeMod
     }
 }
 </code></pre>
-<p>&nbsp;</p>
 <h3>Step 3 - Hooking</h3>
 <p>Hooks allow you to execute your own code when the method you are hooking from the game code is called.</p>
-<p>Hooking is the recommended way of modifying the functionality of the game, as your hooks will allow the hooks of other mods and the game code itself to run as expected (presuming you don&#39;t do something that they don&#39;t expect). From your class constructor or <code>OnEnable</code>, you can subscribe to the event that triggers when a method from the Rain World code is called. If you don&#39;t know how events work, here&#39;s a quick example:</p>
-<pre><code class='language-c#' lang='c#'>[BepInPlugin(&quot;author.my_mod_id&quot;, &quot;SomeModName&quot;, &quot;0.1.0&quot;)]
+<p>Hooking is the recommended way of modifying the functionality of the game, as your hooks will allow the hooks of other mods and the game code itself to run as expected (presuming you don't do something that they don't expect). From your class constructor or <code>OnEnable</code>, you can subscribe to the event that triggers when a method from the Rain World code is called. If you don't know how events work, here's a quick example:</p>
+<pre><code class="language-c#">[BepInPlugin(&quot;author.my_mod_id&quot;, &quot;SomeModName&quot;, &quot;0.1.0&quot;)]
 public class MyMod : BaseUnityPlugin
 {
     public MyMod()
     {
         /* This constructor is called when the mod is loaded. */
-        
+
         // subscribe your PlayerUpdateHook to the Player.Update method from the game
-        // the subscriber should have the same parameters as the game&#39;s method, plus the orig
+        // the subscriber should have the same parameters as the game's method, plus the orig
         On.Player.Update += PlayerUpdateHook;
     }
-    
+
     void PlayerUpdateHook(On.Player.orig_Update orig, Player self, bool eu)
     {
         /* This method will be subscribed to Player.Update. */
-        
-	    // you should always call the orig - it lets other mods and the game do their thing
+
+        // you should always call the orig - it lets other mods and the game do their thing
         orig(self, eu);
         // do other stuff before or after the orig call as necessary
     }
 }
 </code></pre>
-<p>If you have many hooks, consider organising them, perhaps into classes. </p>
+<p>If you have many hooks, consider organising them, perhaps into classes.</p>
 <p><em>&quot;Where can I find these magical and elusive Rain World methods?&quot;</em>
-Since the source code for Rain World is not public, one must use a decompiler such as <a href='https://github.com/dnSpy/dnSpy/releases/latest'>dnSpy</a> or <a href='https://marketplace.visualstudio.com/items?itemName=SharpDevelopTeam.ILSpy'>ILSpy</a> to look through the <code>Assembly-CSharp.dll</code> file. </p>
-<p><em>Reminder: you should never distribute significant portions of the game&#39;s code or the binaries, or that of any closed source mods unless you have explicit permission to do so from the mod author. Pay attention to licenses on public repositories too - see <a href='https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository'>GitHub&#39;s guide to code licensing</a> and if in doubt ask the author.</em></p>
-<p>&nbsp;</p>
+Since the source code for Rain World is not public, one must use a decompiler such as <a href="https://github.com/dnSpy/dnSpy/releases/latest">dnSpy</a> or <a href="https://marketplace.visualstudio.com/items?itemName=SharpDevelopTeam.ILSpy">ILSpy</a> to look through the <code>Assembly-CSharp.dll</code> file.</p>
+<p><em>Reminder: you should never distribute significant portions of the game's code or the binaries, or that of any closed source mods unless you have explicit permission to do so from the mod author. Pay attention to licenses on public repositories too - see <a href="https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/licensing-a-repository">GitHub's guide to code licensing</a> and if in doubt ask the author.</em></p>
 <h3>Testing your code</h3>
-<p>Build your code and copy the mod&#39;s DLL file from wherever your build output is to <code>Rain World/BepInEx/plugins/</code> and run Rain World. </p>
-<p>&nbsp;</p>
+<p>Build your code and copy the mod's DLL file from wherever your build output is to <code>Rain World/BepInEx/plugins/</code> and run Rain World.</p>
 <hr />
 <h2>Next steps</h2>
-<p>So... Where to now? The modding community in the <a href='https://discord.gg/rainworld'>Rain World Discord</a> would love to see what you can concoct! GitHub is a good place for hosting open source code and releases. RainDB is also a good place to share mods - for submission see <a href='https://www.raindb.net/upload.html'>this page</a>. </p>
+<p>So... Where to now? The modding community in the <a href="https://discord.gg/rainworld">Rain World Discord</a> would love to see what you can concoct! GitHub is a good place for hosting open source code and releases. RainDB is also a good place to share mods - for submission see <a href="https://www.raindb.net/upload.html">this page</a>.</p>
+
 </body>
 </html>

--- a/pages/level-editor/Camera-Editor.html
+++ b/pages/level-editor/Camera-Editor.html
@@ -1,17 +1,18 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Camera-Editor</title></head>
-<body><h1>Level Editor: Cameras</h1>
-<p><img src="../../assets/regionDevelopment/levelEditor/cameraEditor.png" referrerpolicy="no-referrer" alt="cameraEditor"></p>
+<title>Camera Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Cameras</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/cameraEditor.png" alt="cameraEditor" /></p>
 <p>In the camera editor you can move, create and delete cameras, as well as influence the perspective rendering of these. The purple border marks the out of bounds of the map, while the red border marks the visible area of the camera. The black double border indicates the amount of camera slide/tilt area, and the green area is a representation of the perspective the camera has.</p>
 <p>To Grab a camera press E. To drop it in place hit P. To create a new camera press N and to delete a camera pick it up and press D.</p>
 <p>the following images are some examples of what can be done with these perspective shifts, as well as a default render for comparison</p>
-<p>&nbsp;</p>
 <h2>Controls</h2>
 <hr />
 <ul>
@@ -21,26 +22,51 @@
 <li>D - delete held camera (after picking up)</li>
 <li>I, K - push/pull background corner from/to foreground corner</li>
 <li>J,L - rotate background corner around foreground corner (no visible change if corners overlap)</li>
-
 </ul>
 <p><em>Warning: Attempting to render with no cameras will crash the editor.</em></p>
-<p>&nbsp;</p>
 <h2>Camera Angles</h2>
 <hr />
 <p>The camera can have its angle changed. This could be done to increase or lessen depth, it is great use to emphasise large structures.</p>
 <p>To change the camera angle (green area), point the cursor towards a corner and then use the I J K L keys. it is of note that this does not follow the classical up/down left/right motion, but a up/down motion away from the rotation point of that corner while J and L rotate the point around the corner of the maximum tilt area.</p>
-<p><img src="../../assets/regionDevelopment/levelEditor/cameraCorner.gif" referrerpolicy="no-referrer" alt="cameraCorner"></p>
-<p>&nbsp;</p>
-<figure><table>
+<p><img src="../../assets/regionDevelopment/levelEditor/cameraCorner.gif" alt="cameraCorner" /></p>
+<table>
 <thead>
-<tr><th style='text-align:center;' ><u>Default Angle Render</u></th></tr></thead>
-<tbody><tr><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngleDefault.png" referrerpolicy="no-referrer" alt="cameraAngleDefault"></td></tr></tbody>
-</table></figure>
-<figure><table>
+<tr>
+  <th style="text-align:center"><u>Default Angle Render</u></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngleDefault.png" alt="cameraAngleDefault" /></td>
+</tr>
+</tbody>
+</table>
+<table>
 <thead>
-<tr><th style='text-align:center;' ><u>Editor View</u></th><th style='text-align:center;' ><u>Render</u></th></tr></thead>
-<tbody><tr><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle1-1.png" referrerpolicy="no-referrer" alt="cameraAngle1-1"></td><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle1-2.png" referrerpolicy="no-referrer" alt="cameraAngle1-2"></td></tr><tr><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle2-1.png" referrerpolicy="no-referrer" alt="cameraAngle2-1"></td><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle2-2.png" referrerpolicy="no-referrer" alt="cameraAngle2-2"></td></tr><tr><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle3-1.png" referrerpolicy="no-referrer" alt="cameraAngle3-1"></td><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle3-2.png" referrerpolicy="no-referrer" alt="cameraAngle3-2"></td></tr><tr><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle4-1.png" referrerpolicy="no-referrer" alt="cameraAngle4-1"></td><td style='text-align:center;' ><img src="../../assets/regionDevelopment/levelEditor/cameraAngle4-2.png" referrerpolicy="no-referrer" alt="cameraAngle4-2"></td></tr></tbody>
-</table></figure>
-<p>&nbsp;</p>
+<tr>
+  <th style="text-align:center"><u>Editor View</u></th>
+  <th style="text-align:center"><u>Render</u></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle1-1.png" alt="cameraAngle1-1" /></td>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle1-2.png" alt="cameraAngle1-2" /></td>
+</tr>
+<tr>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle2-1.png" alt="cameraAngle2-1" /></td>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle2-2.png" alt="cameraAngle2-2" /></td>
+</tr>
+<tr>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle3-1.png" alt="cameraAngle3-1" /></td>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle3-2.png" alt="cameraAngle3-2" /></td>
+</tr>
+<tr>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle4-1.png" alt="cameraAngle4-1" /></td>
+  <td style="text-align:center"><img src="../../assets/regionDevelopment/levelEditor/cameraAngle4-2.png" alt="cameraAngle4-2" /></td>
+</tr>
+</tbody>
+</table>
+
 </body>
 </html>

--- a/pages/level-editor/Effect-Editor.html
+++ b/pages/level-editor/Effect-Editor.html
@@ -1,58 +1,55 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Effect-Editor</title></head>
-<body><h1>Level Editor: Effect Editor</h1>
-<p><img src="../../assets/regionDevelopment/levelEditor/effectEditor.png" referrerpolicy="no-referrer" alt="effectEditor"></p>
-<p>The effect editor is used to modify and add filters to the level&#39;s geometry and tiles. This is the main way you make your levels &quot;look good.&quot; It is largely up for you to paint the effects that will fill your rooms, and all of these effects can be seen in a large gallery picture at the end of the article. However there are a few pointers that hold true for most rooms in Rain World.</p>
+<title>Effect Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Effect Editor</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/effectEditor.png" alt="effectEditor" /></p>
+<p>The effect editor is used to modify and add filters to the level's geometry and tiles. This is the main way you make your levels &quot;look good.&quot; It is largely up for you to paint the effects that will fill your rooms, and all of these effects can be seen in a large gallery picture at the end of the article. However there are a few pointers that hold true for most rooms in Rain World.</p>
 <ul>
 <li>Slime is your friend. Most of Rain World has a light to medium dose of slime all over the room. This effects adds a more messy drippy border to the details of your room, and prevents it from looking too clean.</li>
 <li>BlackGoo is used to create the black outlines to rooms. Apply this effect before the slime is applied if you want a more messy border! Applies in large blots over certain tiles, and will not appear over empty tiles. This effect only applies to layer 1, and will NOT draw on: Random machines, trash, and the smallpipes materials. It will also not draw on almost all tiles.</li>
 <li>Dirt and large trash make good material borders for natural rooms where you want the black goo to appear.</li>
 <li>Large trash covered in black goo works well for the borders of machinery inside walls, and mechanical areas.</li>
-<li>Concrete blocks, and large trash work well for the borders of more urban areas. However the more blocky materials are often a bit harder to make look good. Don&#39;t be discouraged, keep playing around until you are happy with the effects and tiles!</li>
+<li>Concrete blocks, and large trash work well for the borders of more urban areas. However the more blocky materials are often a bit harder to make look good. Don't be discouraged, keep playing around until you are happy with the effects and tiles!</li>
 <li>Some effects work best with certain tiles, and certain effects require certain tiles under them to properly be applied. ( Such as ceramic chaos effect, requiring the ceramic tile material on the walls!)</li>
-<li>Unlike other effects, the BlackGoo effect starts applied to the whole room. Instead of using left-click to paint it in, use right-click to erase the areas you don&#39;t want it to apply to.</li>
-
+<li>Unlike other effects, the BlackGoo effect starts applied to the whole room. Instead of using left-click to paint it in, use right-click to erase the areas you don't want it to apply to.</li>
 </ul>
-<p>&nbsp;</p>
 <h2>Controls:</h2>
 <hr />
 <h4>Effect library:</h4>
 <ul>
-<li>A, D - Changes effect library&#39;s category</li>
+<li>A, D - Changes effect library's category</li>
 <li>W, S - Scrolls through effect in current category</li>
 <li>E - Switches to editing previously applied effects.</li>
 <li>Space - Adds the selected effect.</li>
-
 </ul>
 <h4>Applied effects:</h4>
 <ul>
 <li>W, S - Scrolls through effects applied in room</li>
 <li>N - Switches to adding new effects from the effect library.</li>
 <li>Space - edit selected effect</li>
-
 </ul>
 <h4>Effect editing:</h4>
 <ul>
-<li>A, D - Scrolls through options in the effect&#39;s menu</li>
-<li>W, S - Changes the current effect&#39;s menu</li>
+<li>A, D - Scrolls through options in the effect's menu</li>
+<li>W, S - Changes the current effect's menu</li>
 <li>Space - activates selected option in effect menu</li>
 <li>Mouse left - Paints current effect</li>
 <li>Mouse right - removes current effect</li>
 <li>R - Grows cursor</li>
 <li>F - Shrinks cursor</li>
 <li>E or N - Switches back to the menus for editing or adding effects respectively.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Effect Gallery</h2>
 <hr />
 <p>Not all effects are shown in their best light here. Experiment and mix effects to create rooms that fit the style and shape of the regions or arenas you want to create!</p>
-<p><img src="../../assets/regionDevelopment/levelEditor/effectGallery.png" referrerpolicy="no-referrer" alt="effectGallery"></p>
+<p><img src="../../assets/regionDevelopment/levelEditor/effectGallery.png" alt="effectGallery" /></p>
+
 </body>
 </html>

--- a/pages/level-editor/Geometry-Editor.html
+++ b/pages/level-editor/Geometry-Editor.html
@@ -1,25 +1,24 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Geometry-Editor</title></head>
-<body><h1>Level Editor: Geometry Editor</h1>
-<p><img src="../../assets/regionDevelopment/levelEditor/geoEditor.png" referrerpolicy="no-referrer" alt="geoEditor"></p>
-<p>The Geometry Editor is the first stop for the creation of new rooms. In the Geometry Editor, you define the gameplay and collision information of your room, as well as the placement of vertical and horizontal bars, shortcuts, entrances and exits (to connect your room to other rooms), and a number of other gameplay relevant elements. Once you have defined your geometry (and ideally play tested your room in-engine) you can move on to the <a href='Tile-Editor.html'>Tile Editor</a> to define the look and props that make up your geometry.</p>
-<p>&nbsp;</p>
+<title>Geometry Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Geometry Editor</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/geoEditor.png" alt="geoEditor" /></p>
+<p>The Geometry Editor is the first stop for the creation of new rooms. In the Geometry Editor, you define the gameplay and collision information of your room, as well as the placement of vertical and horizontal bars, shortcuts, entrances and exits (to connect your room to other rooms), and a number of other gameplay relevant elements. Once you have defined your geometry (and ideally play tested your room in-engine) you can move on to the <a href="Tile-Editor.html">Tile Editor</a> to define the look and props that make up your geometry.</p>
 <h2>Controls</h2>
 <hr />
 <p>The arrow keys on your keyboard allow you to change which tool you have selected in the top left panel.</p>
 <p>You move the red cursor with the mouse. Left click places elements (and in some cases is also used to remove them).</p>
 <p>Numpad 4,8,6 and 2 move the section of your room currently visible in the editor (a selection that is carried forward into the Tile Editor).</p>
-<p>As always, 1 will return you to the <a href='Official-Level-Editor.html'>dashboard</a> to save your progress or move to a different editor.</p>
-<p>&nbsp;</p>
+<p>As always, 1 will return you to the <a href="Official-Level-Editor.html">dashboard</a> to save your progress or move to a different editor.</p>
 <h4>Secondary Controls</h4>
 <p>As an experimental feature, the developers implemented a second cursor and control scheme to allow two users to edit a room simultaneously (with the second user entirely on the keyboard). While this ended up being a little used feature (as far as we are aware), it is still implemented in the current editor (represented by the grey cursor).</p>
-<p>&nbsp;</p>
 <h2>Toolbox</h2>
 <hr />
 <p>Starting from the top left, and going through each row.</p>
@@ -29,7 +28,7 @@
 <li>Paint Air: Paints non-solid tiles.</li>
 <li>Make Slope: Paints a slope, these can only be placed inside corners, and as the edges of larger solids</li>
 <li>Make Floor: Paints thin platforms that you can stand on, but also hold down to fall through.</li>
-<li>Rect Wall: paints solid tiles in a rectangle. Click two points to set the rectangle&#39;s dimensions and paint.</li>
+<li>Rect Wall: paints solid tiles in a rectangle. Click two points to set the rectangle's dimensions and paint.</li>
 <li>Rect Air: Same as above, except for non-solid tiles.</li>
 <li>Move Level: Moves the whole level in a certain direction. Place the mouse cursor outside the level, then use the arrow keys to move the level in the direction you want. It will not work if your mouse is inside the level as using the arrow keys will swap to another tool.</li>
 <li>Place Rock: A Rock will spawn at this location with a 60% chance.</li>
@@ -41,8 +40,8 @@
 <li>Glass Wall: Paints invisible solid walls.</li>
 <li>Copy Backwards: Copies a rectangle of tiles on the current layer to the next layer. This does not wrap around back to layer 1 if you are on layer 3.</li>
 <li>Short Cut Entrance: Places the entrance of a short cut into the room. Please see the tips and tricks section for details of how to properly connect entrances and doors together.</li>
-<li>Short Cut: Places a short cut&#39;s travel dot. These go between short cut entrances, and specific entrance or den tiles.</li>
-<li>Dragon Den: Places an enemy nest. These can be configured to spawn enemies in a region using the region&#39;s <a href='../level-editor/World-File-Format.html'>World File</a>.</li>
+<li>Short Cut: Places a short cut's travel dot. These go between short cut entrances, and specific entrance or den tiles.</li>
+<li>Dragon Den: Places an enemy nest. These can be configured to spawn enemies in a region using the region's <a href="../region-development/World-File-Format.html">World File</a>.</li>
 <li>Entrance: Used to connect between rooms. Slugcat can use these short cuts as doors to different rooms. This is configured in the regions world file.</li>
 <li>Forbid Fly Chains: Prevents bat flies from hanging together in specific locations to rest.</li>
 <li>Spawn Fly: Does nothing.</li>
@@ -56,33 +55,30 @@
 <li>Clear All: Selects a rectangle that resets all tiles inside it, on all layers, back to open air.</li>
 <li>Toggle Mirror: Turns on and off a mirror tile painting mode. What you do on one side of the mirror will be copied on the other.</li>
 <li>Move Mirror: Allows you to move the location of the Mirror.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Short Cuts and Entrances</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts1.gif" referrerpolicy="no-referrer" alt="geoShortcuts1"><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts2.png" referrerpolicy="no-referrer" alt="geoShortcuts2"><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts3.png" referrerpolicy="no-referrer" alt="geoShortcuts3"></p>
+<p><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts1.gif" alt="geoShortcuts1" /><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts2.png" alt="geoShortcuts2" /><img src="../../assets/regionDevelopment/levelEditor/geoShortcuts3.png" alt="geoShortcuts3" /></p>
 <p>Short cuts and their connections to the various kinds of entrances in Rain World have specific needs! Improperly making the short cut can lead to crashes, or odd behavior in game. This gif presents several examples of properly linked short cuts.</p>
-<p>A short cut dot is not required between the short cut&#39;s entrance, and the den or door it is connecting to. However, the shortcut must show as an arrow toward the den or door for the link to it to be proper. The short cut entrance also requires walls surrounding it on all sides, with the exception of the side you will enter it from.</p>
-<p>Connecting two short cut entrances to each other with dots will connect them as a tunnel between the two. The various other den and entrance types will decide how enemies interact with the entrance. Dens are used for most normal creatures. Scavenger require their unique entrance type to enter the room properly without using normal doors. ( They will not be able to leave the OFFSCREEN room of the region if there are no scavenger doors at all in the region! ) Garbage worms require a unique door due to their AI&#39;s behavior, and cannot use normal dens, nore can enemies enter their dens. Finally the Whack-A-Mole holes are used by creatures to warp from various short cuts around the room.</p>
+<p>A short cut dot is not required between the short cut's entrance, and the den or door it is connecting to. However, the shortcut must show as an arrow toward the den or door for the link to it to be proper. The short cut entrance also requires walls surrounding it on all sides, with the exception of the side you will enter it from.</p>
+<p>Connecting two short cut entrances to each other with dots will connect them as a tunnel between the two. The various other den and entrance types will decide how enemies interact with the entrance. Dens are used for most normal creatures. Scavenger require their unique entrance type to enter the room properly without using normal doors. ( They will not be able to leave the OFFSCREEN room of the region if there are no scavenger doors at all in the region! ) Garbage worms require a unique door due to their AI's behavior, and cannot use normal dens, nore can enemies enter their dens. Finally the Whack-A-Mole holes are used by creatures to warp from various short cuts around the room.</p>
 <p>The images on the right also display the bare minimum needed for short cut entrances to function, and example doors in all directions.</p>
-<p>&nbsp;</p>
 <h2>Layer Info</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/levelEditor/geoLayers.gif" referrerpolicy="no-referrer" alt="geoLayers"></p>
+<p><img src="../../assets/regionDevelopment/levelEditor/geoLayers.gif" alt="geoLayers" /></p>
 <p>Rain World levels consist of 3 layers, each representing a different depth. This layer info is represented</p>
 <p>visually through the color of tiles, and you can switch between editing on different layers with the work layer tool in the bottom left of the tool panel. Layer 1 draws in full black, layer 2 draws in green, and layer 3 draws in red. These colors will blend if multiple layers are drawn on top of each other.</p>
 <p>Layer 1 is the foreground, and any filled tiles on this layer will have collision. This is the base layer you define for the sake of gameplay, as any air here is space you can traverse.</p>
 <p>Layer 2 is the midground, which you can imagine as the back wall of your room.</p>
 <p>Layer 3 is the extreme background, behind the back wall of the room (for placing distant objects or giving the room a section of open sky).</p>
 <p><strong>Note:</strong> The tile editor defines the visual tiles and props that make up this geometry, so in order to place solid objects in the tile editor (on any layer), those tiles need to be filled here in the geometry editor. Even though the mid-ground and background do not provide any collision geometry, in order to place solid props on those layers the tiles need to be filled here in the geometry editor. Similarly, some props can only be placed on air on the layers (like fences).</p>
-<p>&nbsp;</p>
 <h2>Tips and Tricks</h2>
 <hr />
 <p>Many of the gameplay features require that they be placed within the margins of your room (represented by the white border). An entrance placed outside of your margins will render your room un-enterable, for example.</p>
-<p>Because the tool panel loops around from top to bottom and left to right, when editing the base geometry (walls and air) it&#39;s faster to use the arrow keys to go up to reach the work layer tool to swap layers than to cycle through the whole list to reach them. Also, the rectangular wall and air tools will let you edit large chunks of your level much faster than going tile by tile.</p>
-<p><strong>SHORTCUTS:</strong> In order to place functional shortcuts, the shortcut entrance needs to be inset by one tile, and the tile adjacent to it needs to be surrounded by walls on 2 sides (the image above should help clarify what I mean). If the shortcut entrance looks like a hollow circle, it isn&#39;t correctly configured (once it is, it will look like the entrances in the above screenshot).</p>
+<p>Because the tool panel loops around from top to bottom and left to right, when editing the base geometry (walls and air) it's faster to use the arrow keys to go up to reach the work layer tool to swap layers than to cycle through the whole list to reach them. Also, the rectangular wall and air tools will let you edit large chunks of your level much faster than going tile by tile.</p>
+<p><strong>SHORTCUTS:</strong> In order to place functional shortcuts, the shortcut entrance needs to be inset by one tile, and the tile adjacent to it needs to be surrounded by walls on 2 sides (the image above should help clarify what I mean). If the shortcut entrance looks like a hollow circle, it isn't correctly configured (once it is, it will look like the entrances in the above screenshot).</p>
 <p><strong>ENTRANCES:</strong> Setting up entrances to your room is similar to shortcuts, the only difference being that rather than connect to another shortcut entrance, your shortcut dots need to connect to a tile marked as an entrance. This entrance (denoted by a P) MUST be within the level and not on the margins. In order to ensure that your level will function, I recommend at least a one tile gap (a &quot;rule&quot; violated by the right entrance in the above screenshot).</p>
-<p><strong>LAYER OVERLAP:</strong> Because the layers move with a parallax effect, it&#39;s often necessary to extend elements on your background layer behind your other layers, otherwise the camera angle will sometimes let you see a gap to the left or right of a background wall and the layer in front of it (for example).</p>
+<p><strong>LAYER OVERLAP:</strong> Because the layers move with a parallax effect, it's often necessary to extend elements on your background layer behind your other layers, otherwise the camera angle will sometimes let you see a gap to the left or right of a background wall and the layer in front of it (for example).</p>
+
 </body>
 </html>

--- a/pages/level-editor/Light-Editor.html
+++ b/pages/level-editor/Light-Editor.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Light-Editor</title></head>
-<body><h1>Level Editor: Light Editor</h1>
-<h2><strong><em><u>This article is a stub and needs to be updated!</u></em></strong></h2>
-<p><img src="../../assets/regionDevelopment/levelEditor/lightEditor.png" referrerpolicy="no-referrer" alt="lightEditor"></p>
+<title>Light Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Light Editor</h1>
+<h2>*<strong><u>This article is a stub and needs to be updated!</u></strong>*</h2>
+<p><img src="../../assets/regionDevelopment/levelEditor/lightEditor.png" alt="lightEditor" /></p>
 <h2>Controls</h2>
 <hr />
 <ul>
@@ -21,14 +23,13 @@
 <li>J, L - Change angle of light source</li>
 <li>I, K - Change distance of light source</li>
 <li>8, 4, 2, 6 (numpad) - move view, where (8 = ↑, 4 = ←, 2 = ↓, 6 = →)</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Canvas stretching</h2>
 <hr />
 <p>Corners of the canvas can be dragged by holding down keys C, V, B and N (up-left, up-right, down-right and down-left respectively). After deformation, folded canvas can be reapplied by pressing M. This will project deformed version onto main layer.</p>
 <p>Once dragged, canvas corners are hard to return to their initial position. Deformation is reset by leaving and re-entering the light editor tab.</p>
 <p>Deforming the canvas may deform some buttons in the main menu.</p>
-<p><strong>*Note:</strong> The light editor has a bug in which the border constraints (i.e. the view you can move with the numpad keys) is offset, often causing the upper and left areas of the room to be inaccessible in this editor. A workaround is to hold numpad9 while moving the view, which bypasses these restrictions. Alternatively, the PNG file found with the editor save txt in the LevelEditorProjects folder is the same as what appears in the light editor, and can be modified using an image editor.*</p>
+<p>*<strong>Note:</strong> The light editor has a bug in which the border constraints (i.e. the view you can move with the numpad keys) is offset, often causing the upper and left areas of the room to be inaccessible in this editor. A workaround is to hold numpad9 while moving the view, which bypasses these restrictions. Alternatively, the PNG file found with the editor save txt in the LevelEditorProjects folder is the same as what appears in the light editor, and can be modified using an image editor.*</p>
+
 </body>
 </html>

--- a/pages/level-editor/Official-Level-Editor.html
+++ b/pages/level-editor/Official-Level-Editor.html
@@ -1,24 +1,22 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Official-Level-Editor</title></head>
-<body><h1>The Official Level Editor</h1>
-<p><img src="../../assets/regionDevelopment/levelEditor/editorFront.png" referrerpolicy="no-referrer" alt="editorFront"></p>
+<title>Official Level Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>The Official Level Editor</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/editorFront.png" alt="editorFront" /></p>
 <p>The Rain World level editor is a powerful tool that allows for the creation of new rooms for the game. It is the same editor the developers used to make all of the rooms for the base game. It takes specially formatted spritesheets and a number of programmed effects and outputs png files that the engine interprets in 3D (as well as an accompanying text file which contains collision and gameplay info).</p>
-<p>You can download the level editor from <a href='https://ln.sync.com/dl/db7b0cf70/nebg7d6b-qg7gjua7-gjdi94jn-xuvivhw3'>here</a>.</p>
-<p>&nbsp;</p>
+<p>You can download the level editor from <a href="https://ln.sync.com/dl/db7b0cf70/nebg7d6b-qg7gjua7-gjdi94jn-xuvivhw3">here</a>.</p>
 <h2>Basic Features Overview</h2>
 <hr />
-<p>&nbsp;</p>
-<p>Once you&#39;ve followed the on-screen instructions for either creating or opening a level, you are presented with the dashboard/preview screen.  From here, you can switch between the different editors, load or save your level, and export it for use in-game.  The preview presented here requires being manually updated whenever changes are made or when you first open a level.  Pressing &quot;1&quot; at any point will bring you back to this screen so you can save your level or switch to a different editor.</p>
-<p>
-It&#39;s often best to start by modifying the dimensions of the room to your liking using the level size button before beginning to edit.  You can change this at any time, but because you set the dimensions manually rather than visually, making changes later is more difficult and poses the risk of accidentally deleting a portion of your room if you aren&#39;t careful.</p>
-<p>From the dashboard you can switch to the <a href='Geometry-Editor.html'>Geometry Editor</a> (for defining the level geometry and collision), the <a href='Tile-Editor.html'>Tile Editor</a> (for customizing the tiles and assets that make up the geometry created in the geometry editor), the <a href='Effect-Editor.html'>Effects Editor</a> (for adding procedural effects like erosion or slime, as well as things like plants or chains), the <a href='Light-Editor.html'>Light Editor</a> (for customizing the light and shadow in your room), or the <a href='Prop-Editor.html'>Prop Editor</a> (for adding additional hand placed props and decals like graffiti).</p>
-<p>&nbsp;</p>
+<p>Once you've followed the on-screen instructions for either creating or opening a level, you are presented with the dashboard/preview screen.  From here, you can switch between the different editors, load or save your level, and export it for use in-game.  The preview presented here requires being manually updated whenever changes are made or when you first open a level.  Pressing &quot;1&quot; at any point will bring you back to this screen so you can save your level or switch to a different editor.</p>
+<p>It's often best to start by modifying the dimensions of the room to your liking using the level size button before beginning to edit.  You can change this at any time, but because you set the dimensions manually rather than visually, making changes later is more difficult and poses the risk of accidentally deleting a portion of your room if you aren't careful.</p>
+<p>From the dashboard you can switch to the <a href="Geometry-Editor.html">Geometry Editor</a> (for defining the level geometry and collision), the <a href="Tile-Editor.html">Tile Editor</a> (for customizing the tiles and assets that make up the geometry created in the geometry editor), the <a href="Effect-Editor.html">Effects Editor</a> (for adding procedural effects like erosion or slime, as well as things like plants or chains), the <a href="Light-Editor.html">Light Editor</a> (for customizing the light and shadow in your room), or the <a href="Prop-Editor.html">Prop Editor</a> (for adding additional hand placed props and decals like graffiti).</p>
 <h2>Control Overview</h2>
 <hr />
 <h3>View controls(numpad):</h3>
@@ -28,9 +26,7 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>1 - Scrolls the view quickly when held, and a view direction is pressed.</li>
 <li>3 - Even faster scroll than above.</li>
 <li>9 - Allow the view to move outside the boundaries of the level.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Menu buttons(Number row):</h3>
 <ul>
 <li>1 - Main menu</li>
@@ -39,25 +35,21 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>4 - camera editor</li>
 <li>5 - Light editor</li>
 <li>6 - Room size</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Geometry Editor:</h3>
-<p>Full article here <a href='Geometry-Editor.html'>Geometry Editor</a>.</p>
+<p>Full article here <a href="Geometry-Editor.html">Geometry Editor</a>.</p>
 <ul>
 <li>Arrow keys - Tool selection( if mouse is over main view. If mouse is over the tools, it will move the cursor instead.)</li>
 <li>Mouse movement - Primary cursor movement</li>
 <li>E,S,D,F - Secondary cursor movement</li>
 <li>Mouse left - Primary cursor, use current tool</li>
 <li>W - Secondary cursor, use current tool</li>
-<li>Q - Hold, and press the secondary cursor&#39;s movement keys to select the secondary cursor&#39;s current tool.</li>
-
+<li>Q - Hold, and press the secondary cursor's movement keys to select the secondary cursor's current tool.</li>
 </ul>
-<p>&nbsp;</p>
 <h3>Tile Editor:</h3>
-<p>Full article here <a href='Tile-Editor.html'>Tile Editor</a>.</p>
+<p>Full article here <a href="Tile-Editor.html">Tile Editor</a>.</p>
 <ul>
-<li>A, D - Changes tile library&#39;s category</li>
+<li>A, D - Changes tile library's category</li>
 <li>W, S - Scrolls through tiles in current category</li>
 <li>Mouse left - Place currently selected tile if possible</li>
 <li>Mouse right - Remove tile under cursor</li>
@@ -68,52 +60,44 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>E - Sets the default material of unpainted tiles. Only works in the &quot;material&quot; category</li>
 <li>F - Forces a tile that requires certain geometry to be placed, without changing any geometry data.</li>
 <li>G - Forces a tile that requires certain geometry to be placed, and adds the required geometry.</li>
-<li>Q - Functions as an &quot;Eyedropper&quot; tool, selecting the tile you&#39;re hovering over to place.</li>
-
+<li>Q - Functions as an &quot;Eyedropper&quot; tool, selecting the tile you're hovering over to place.</li>
 </ul>
-<p>&nbsp;</p>
 <h3>Effect Editor:</h3>
-<p>Full article here <a href='Effect-Editor.html'>Effects Editor</a>.</p>
+<p>Full article here <a href="Effect-Editor.html">Effects Editor</a>.</p>
 <h5>Effect library:</h5>
 <ul>
-<li>A, D - Changes effect library&#39;s category</li>
+<li>A, D - Changes effect library's category</li>
 <li>W, S - Scrolls through effect in current category</li>
 <li>E - Switches to editing previously applied effects.</li>
 <li>Space - Adds the selected effect.</li>
-
 </ul>
 <h5>Applied effects:</h5>
 <ul>
 <li>W, S - Scrolls through effects applied in room</li>
 <li>N - Switches to adding new effects from the effect library.</li>
 <li>Space - edit selected effect</li>
-
 </ul>
 <h5>Effect editing:</h5>
 <ul>
-<li>A, D - Scrolls through options in the effect&#39;s menu</li>
-<li>W, S - Changes the current effect&#39;s menu</li>
+<li>A, D - Scrolls through options in the effect's menu</li>
+<li>W, S - Changes the current effect's menu</li>
 <li>Space - activates selected option in effect menu</li>
 <li>Mouse left - Paints current effect</li>
 <li>Mouse right - removes current effect</li>
 <li>R - Grows cursor</li>
 <li>F - Shrinks cursor</li>
 <li>E or N - Switches back to the menus for editing or adding effects respectively.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Camera Editor:</h3>
-<p>Full article here <a href='Camera-Editor.html'>Camera Editor</a>.</p>
+<p>Full article here <a href="Camera-Editor.html">Camera Editor</a>.</p>
 <ul>
 <li>N - New camera, spawns held by mouse</li>
 <li>E - grab a camera if none is held</li>
 <li>D - Delete held camera</li>
 <li>P - Place held camera</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Light editor:</h3>
-<p>Full article here <a href='Light-Editor.html'>Light Editor</a>.</p>
+<p>Full article here <a href="Light-Editor.html">Light Editor</a>.</p>
 <ul>
 <li>W,A,S,D - Scale current light shape</li>
 <li>Q, E - Rotate current light shape</li>
@@ -123,13 +107,11 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>R, F - Scroll through light shape library</li>
 <li>J, L - Change angle of light source</li>
 <li>I, K - Change distance of light source</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Prop Editor:</h3>
-<p>Full article here <a href='Prop-Editor.html'>Prop Editor</a>.</p>
+<p>Full article here <a href="Prop-Editor.html">Prop Editor</a>.</p>
 <ul>
-<li>A, D - Changes prop library&#39;s category</li>
+<li>A, D - Changes prop library's category</li>
 <li>W, S - Scrolls through props in current category</li>
 <li>Mouse left - Place current prop</li>
 <li>V - Hold and click mouse left to remove highlighted prop</li>
@@ -138,7 +120,7 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>Y,G,H,J - stretch prop</li>
 <li>T - reset prop stretching</li>
 <li>R - reset stretching, and rotation</li>
-<li>Y, H - Only on wires/tube props, Increases or decreases prop&#39;s physics node count. Less means more taught, more means more loose</li>
+<li>Y, H - Only on wires/tube props, Increases or decreases prop's physics node count. Less means more taught, more means more loose</li>
 <li>X - Pause wire/tube physics</li>
 <li>Tab+X+C - clear all props</li>
 <li>B - Click mouse left to set the highlighted prop as the currently selected prop</li>
@@ -148,52 +130,50 @@ It&#39;s often best to start by modifying the dimensions of the room to your lik
 <li>U, I. O, P - Holds a prop by three vertices, and allows you to move the last one with the mouse to stretch it in a freeform manner. ( U stretches top right, I bottom right, O bottom left, and P top left. )</li>
 <li>K - resets freeform stretching.</li>
 <li>N - allows proper properties to be changed. Things like forcing certain graffiti to be drawn instead of a random one.</li>
-<li>M - Click with mouse left, to change the highlighted prop&#39;s properties (does the same as above, except allows you to edit an already placed prop. )</li>
+<li>M - Click with mouse left, to change the highlighted prop's properties (does the same as above, except allows you to edit an already placed prop. )</li>
 <li>Z - Changes prop color</li>
 <li>F + Left or right mouse - Changes between prop variants. This only applies to certain props.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h3>Environment Editor:</h3>
 <ul>
 <li>L - Change water level based on mouse movement</li>
 <li>F - Toggles between drawing water above the first layer or below it.</li>
 <li>W - Removes water from the level if there is already water. If there is no water, sets water level to halfway up the level.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Crash Avoidance and Editor Quirks</h2>
 <hr />
 <p>Due to the editor being extremely user unfriendly, you are likely to run into various crashes without warning. This is a list of various things to avoid doing.</p>
 <h3>Crashes:</h3>
 <ul>
-<li>Do not switch to editing applied effects in the Effects Editor when there are none. The switch will be invisible, and attempting to use the space bar to select something from there will crash the Level Editor.</li>
-<li>Some effects have very specific conditions and cause issues when rendering, Effects include: Thick Roots, and Shadow Plants. these ones can be okayed through until it renders.)</li>
-<li>Be sure to remove tiles from parts of a room that will be removed if you resize the room to cut those areas out, those tiles are still recorded, and will crash renders instantly.</li>
-<li>props are the exact same as above</li>
-<li>Never render with no cameras. It will crash.</li>
-<li>Always move the prop menu into an actual category when you open it, it keeps the last menu used, and crashes if you select any entry that is not a real prop. (EX: it will have the effects menu, or tile menu.)</li>
-
-</ul>
-<ul>
-<li>If you are using the Mirrored tile placer, in the geometry editor. Placing poles, with the other side of the mirrored brush being outside of the room, will crash the editor.</li>
-
+<li><p>Do not switch to editing applied effects in the Effects Editor when there are none. The switch will be invisible, and attempting to use the space bar to select something from there will crash the Level Editor.</p>
+</li>
+<li><p>Some effects have very specific conditions and cause issues when rendering, Effects include: Thick Roots, and Shadow Plants. these ones can be okayed through until it renders.)</p>
+</li>
+<li><p>Be sure to remove tiles from parts of a room that will be removed if you resize the room to cut those areas out, those tiles are still recorded, and will crash renders instantly.</p>
+</li>
+<li><p>props are the exact same as above</p>
+</li>
+<li><p>Never render with no cameras. It will crash.</p>
+</li>
+<li><p>Always move the prop menu into an actual category when you open it, it keeps the last menu used, and crashes if you select any entry that is not a real prop. (EX: it will have the effects menu, or tile menu.)</p>
+</li>
+<li><p>If you are using the Mirrored tile placer, in the geometry editor. Placing poles, with the other side of the mirrored brush being outside of the room, will crash the editor.</p>
+</li>
 </ul>
 <h3>Quirks:</h3>
 <ul>
 <li>The main menu is a mess when you return from using the Light Editor or the Environment Editor. Just change to any other editor (geometry or tiles, and back to main menu) to clean it. This is not a crash, but will help prevent confusion if you know to expect this.</li>
 <li>To use the Move and Move Mirror tools in the editor, you must first select them, and then move your mouse outside of the room itself, before it will respond to your inputs. Usually you will only need to put your mouse over the editor, but in larger rooms, this is often an issue, as the room is &quot;behind&quot; the menu, and thus only changes tool selection.</li>
-<li>The editor still receives inputs if you only tab out using alt-tab. When viewing another window, it&#39;s important to always minimize the editor, because there are many things that can go wrong if you&#39;re randomly clicking in the editor.</li>
+<li>The editor still receives inputs if you only tab out using alt-tab. When viewing another window, it's important to always minimize the editor, because there are many things that can go wrong if you're randomly clicking in the editor.</li>
 <li>(Requires more confirmation) The screen during rendering should usually show the map being rendered, but it may not. In the task manager, The Rain World Editor is under the tab Adobe Projector. Sometimes the reason it is not showing is a second application called &quot;Print driver host for applications&quot;. Closing the application seems to fix the issue.</li>
 <li>The window for the application may be too big to fit on screen, and cannot be fixed since reaching the top bar or right clicking cannot be accessed to move the window.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Demo and Tutorial Videos</h2>
 <hr />
 <p>Region Developer Kaeporo created a tutorial for creating levels in and out of the level editor:</p>
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YQ0DO-fmPCE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YQ0DO-fmPCE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 <p>Mod community member Sacretis also put together a demonstration video, this time covering the creation of a room from scratch to visual polish (massively sped up for the sake of time):</p>
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/sEE3X1izaJA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/sEE3X1izaJA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 </body>
 </html>

--- a/pages/level-editor/Prop-Editor.html
+++ b/pages/level-editor/Prop-Editor.html
@@ -1,18 +1,19 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Prop-Editor</title></head>
-<body><h1>Level Editor: Prop Editor</h1>
-<h2><strong><em><u>This article is a stub and needs to be updated!</u></em></strong></h2>
-<p><img src="../../assets/regionDevelopment/levelEditor/propEditor.png" referrerpolicy="no-referrer" alt="propEditor"></p>
+<title>Prop Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Prop Editor</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/propEditor.png" alt="propEditor" /></p>
 <h2>Controls:</h2>
 <hr />
 <ul>
-<li>A, D - Changes prop library&#39;s category</li>
+<li>A, D - Changes prop library's category</li>
 <li>W, S - Scrolls through props in current category</li>
 <li>Mouse left - Place current prop</li>
 <li>V - Hold and click mouse left to remove highlighted prop</li>
@@ -21,7 +22,7 @@
 <li>Y,G,H,J - stretch prop</li>
 <li>T - reset prop stretching</li>
 <li>R - reset stretching, and rotation</li>
-<li>Y,H - Only on wires/tube props, Increases or decreases prop&#39;s physics node count. Less means more taught, more means more loose</li>
+<li>Y,H - Only on wires/tube props, Increases or decreases prop's physics node count. Less means more taught, more means more loose</li>
 <li>X - Pause wire/tube physics</li>
 <li>Tab+X+C - clear all props</li>
 <li>B - Click mouse left to set the highlighted prop as the currently selected prop</li>
@@ -31,11 +32,11 @@
 <li>U, I. O, P - Holds a prop by three vertices, and allows you to move the last one with the mouse to stretch it in a freeform manner. ( U stretches top right, I bottom right, O bottom left, and P top left. )</li>
 <li>K - resets freeform stretching.</li>
 <li>N - allows proper properties to be changed. Things like forcing certain graffiti to be drawn instead of a random one.</li>
-<li>M - Click with mouse left, to change the highlighted prop&#39;s properties (does the same as above, except allows you to edit an already placed prop. )</li>
+<li>M - Click with mouse left, to change the highlighted prop's properties (does the same as above, except allows you to edit an already placed prop. )</li>
 <li>Z - Changes prop color</li>
 <li>F + Left or right mouse - Changes between prop variants. This only applies to certain props.</li>
 <li>B - Navigates the prop library to the selected prop.</li>
-
 </ul>
+
 </body>
 </html>

--- a/pages/level-editor/Tile-Editor.html
+++ b/pages/level-editor/Tile-Editor.html
@@ -1,16 +1,17 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Tile-Editor</title></head>
-<body><h1>Level Editor: Tile Editor</h1>
-<p><img src="../../assets/regionDevelopment/levelEditor/tileEditor.png" referrerpolicy="no-referrer" alt="tileEditor"></p>
-<p>The Tile Editor is where you define the tiles and materials that provide the visual representation of the level geometry created in the <a href='Geometry-Editor.html'>Geometry Editor</a>. Because the actual coloring of levels is done dynamically in-engine, Level creators are afforded incredible flexibility in the tiles and tile combinations that match. On top of that, the game shipped with a massive asset library which can be leveraged to create new and exciting styles. Tiles in the tile editor span the range from small nondescript square stones to the massive metal gates connecting regions.</p>
+<title>Tile Editor (Rain World Modding)</title>
+</head>
+<body>
+<h1>Level Editor: Tile Editor</h1>
+<p><img src="../../assets/regionDevelopment/levelEditor/tileEditor.png" alt="tileEditor" /></p>
+<p>The Tile Editor is where you define the tiles and materials that provide the visual representation of the level geometry created in the <a href="Geometry-Editor.html">Geometry Editor</a>. Because the actual coloring of levels is done dynamically in-engine, Level creators are afforded incredible flexibility in the tiles and tile combinations that match. On top of that, the game shipped with a massive asset library which can be leveraged to create new and exciting styles. Tiles in the tile editor span the range from small nondescript square stones to the massive metal gates connecting regions.</p>
 <p>The base of your intended visual style stems from the tile choices you make here in the Tile Editor. Further refinement of the art and aesthetic style comes from later work in the Effects Editor, Light Editor, and Prop Editor.</p>
-<p>&nbsp;</p>
 <h2>Controls</h2>
 <hr />
 <p>On the right side of the screen, A and D allow you to select from the available tile categories. W and S allow you to select a tile from the chosen category.</p>
@@ -20,17 +21,16 @@
 <p>L changes the active layer (displayed in the bottom right).</p>
 <p>F and V changes the material placing brush to 3x3 and 5x5 respectively.</p>
 <p>G forces a tile to place with the geometry of the tile. F forces a tile to place without the geometry of the tile.</p>
-<p>Tab + X + C clears all tiles (<strong><em>there is no undo button</em></strong>, only reloading from a previous save, so BE CAREFUL).</p>
-<p>&nbsp;</p>
+<p>Tab + X + C clears all tiles (*<strong>there is no undo button</strong>*, only reloading from a previous save, so BE CAREFUL).</p>
 <h2>Tile Types</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/levelEditor/tileMaterials.png" referrerpolicy="no-referrer" alt="tileMaterials"></p>
+<p><img src="../../assets/regionDevelopment/levelEditor/tileMaterials.png" alt="tileMaterials" /></p>
 <p>Tiles come in a variety of flavors. Materials are the core and most flexible tiles as they procedurally generate to fill any size or shape. With the Materials category selected, an option to choose the default material appears (select the intended material and press E to assign it). The default material will be applied to any solid grid squares not manually assigned to something else. Materials are represented by colored squares in the tile editor. Pictured to the right is a fantastic cheat sheet made by AndrewFM that gives you a preview of each of the materials.</p>
-<p>Outside of materials, the rest of the tiles are designed to either fill solid geometry (like stone blocks) or air (like fences). Some tiles require a specific pattern of both (like the crawlspaces which require walls on either side and air in the center). Tiles will appear red and refuse to place if they aren&#39;t on a grid square with the type of geometry they require, so some experimentation is required. The dark grey grid in the bottom right provides a preview of the necessary geometry if you&#39;re struggling to figure out why a tile won&#39;t place.</p>
+<p>Outside of materials, the rest of the tiles are designed to either fill solid geometry (like stone blocks) or air (like fences). Some tiles require a specific pattern of both (like the crawlspaces which require walls on either side and air in the center). Tiles will appear red and refuse to place if they aren't on a grid square with the type of geometry they require, so some experimentation is required. The dark grey grid in the bottom right provides a preview of the necessary geometry if you're struggling to figure out why a tile won't place.</p>
 <p>Unfortunately, outside of the awesome cheat sheet for materials AndrewFM put together, the only way to know what a tile actually looks like is to render the level, and while most of the editor previews are pretty accurate, some can be misleading. Because of this, occasionally doing a test render is highly recommended before pouring hours into tile details. It can also be helpful to make your own test sheets before detailing a room. By rendering a simple test room filled with the tiles that you think might fit your intended style or that catch your eye, you can save yourself a lot of time carefully arranging a bunch of things that turn out to look nothing like you hoped.</p>
-<p>&nbsp;</p>
 <h2>Tile Cheat Sheets</h2>
 <hr />
-<p><a href='https://imgur.com/a/Vz3Kk' target='_blank' class='url'>https://imgur.com/a/Vz3Kk</a></p>
+<p>https://imgur.com/a/Vz3Kk</p>
+
 </body>
 </html>

--- a/pages/region-development/Adding-A-New-Region.html
+++ b/pages/region-development/Adding-A-New-Region.html
@@ -1,41 +1,54 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
-<script src='../../scripts/extras.js'></script>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Adding-A-New-Region</title></head>
-<body><h1>Adding A New Region</h1>
-<h2><strong><em><u>This article is outdated and needs updating!</u></em></strong></h2>
-<p>## </p>
-<ol start='' >
-<li>Pick a two letter acronym for your region. For these examples we&#39;ll use XX</li>
-<li>Open the file &quot;Rain World/World/Regions/regions.txt&quot;</li>
-<li>Add your two letter acronym to the end of the file.</li>
-<li>Create a new folder in the Regions directory with your two letter acronym</li>
-<li>Copy files over from one of the other regions to use as a template</li>
-<li>Rename instances of the old region&#39;s acronym to your new region&#39;s acronym</li>
-
+<title>Adding A New Region (Rain World Modding)</title>
+</head>
+<body>
+<h1>Adding A New Region</h1>
+<h2>*<strong><u>This article is outdated and needs updating!</u></strong>*</h2>
+<h2></h2>
+<ol>
+<li><p>Pick a two letter acronym for your region. For these examples we'll use XX</p>
+</li>
+<li><p>Open the file &quot;Rain World/World/Regions/regions.txt&quot;</p>
+</li>
+<li><p>Add your two letter acronym to the end of the file.</p>
+</li>
+<li><p>Create a new folder in the Regions directory with your two letter acronym</p>
+</li>
+<li><p>Copy files over from one of the other regions to use as a template</p>
+</li>
+<li><p>Rename instances of the old region's acronym to your new region's acronym</p>
+</li>
 </ol>
-<p>  6a. I recommend blanking out the map_XX file entirely</p>
-<p>  6b. Remove all Room_Attr lines from the Properties file</p>
-<p>  6c. Delete everything from the Rooms folder, leaving just one room to use as your start map to build off of.</p>
-<p>  6d. Blank out most of the ROOMS and CREATURES sections from the world_XX file.
-  		- If you want Vultures/Leviathans/Scavengers in your region, leave the OFFSCREEN section under CREATURES
-  		- You&#39;ll add a couple lines under ROOM for connecting the gate and your start room, so your region at least has SOMETHING in it (once you make the gate).</p>
-<p>&nbsp;</p>
+<p>6a. I recommend blanking out the map_XX file entirely</p>
+<p>6b. Remove all Room_Attr lines from the Properties file</p>
+<p>6c. Delete everything from the Rooms folder, leaving just one room to use as your start map to build off of.</p>
+<p>6d. Blank out most of the ROOMS and CREATURES sections from the world_XX file.
+    	- If you want Vultures/Leviathans/Scavengers in your region, leave the OFFSCREEN section under CREATURES
+    	- You'll add a couple lines under ROOM for connecting the gate and your start room, so your region at least has SOMETHING in it (once you make the gate).</p>
 <h2>Adding the Gate</h2>
 <hr />
-<ol start='' >
-<li>Go to the &quot;Rain World/World/Gates&quot; folder</li>
-<li>Take one of the gates in here to use as a base, and copy/paste it</li>
-<li>Rename the copies to match your region connection. For example, if you&#39;re connecting to SU, name the files GATE_SU_XX</li>
-<li>You&#39;ll also need to open the GATE_YY_XX.txt file and edit the first line of the file to match</li>
-<li>Open the file &quot;Rain World/World/Gates/locks.txt&quot;</li>
-<li>Add a new line for your new gate, and specify the karma requirements for the two sides of the gate</li>
-<li>Go back to each of the two regions and add connections to the gate in their world_XX.txt files</li>
-
+<ol>
+<li><p>Go to the &quot;Rain World/World/Gates&quot; folder</p>
+</li>
+<li><p>Take one of the gates in here to use as a base, and copy/paste it</p>
+</li>
+<li><p>Rename the copies to match your region connection. For example, if you're connecting to SU, name the files GATE_SU_XX</p>
+</li>
+<li><p>You'll also need to open the GATE_YY_XX.txt file and edit the first line of the file to match</p>
+</li>
+<li><p>Open the file &quot;Rain World/World/Gates/locks.txt&quot;</p>
+</li>
+<li><p>Add a new line for your new gate, and specify the karma requirements for the two sides of the gate</p>
+</li>
+<li><p>Go back to each of the two regions and add connections to the gate in their world_XX.txt files</p>
+</li>
 </ol>
+
 </body>
 </html>

--- a/pages/region-development/Architecture-of-Rain-World.html
+++ b/pages/region-development/Architecture-of-Rain-World.html
@@ -1,49 +1,49 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Architecture-of-Rain-World</title></head>
-<body><h1>The Architecture of Rain World</h1>
+<title>Architecture of Rain World (Rain World Modding)</title>
+</head>
+<body>
+<h1>The Architecture of Rain World</h1>
 <h2><strong><u>This article is contains outdated information and needs to be updated!</u></strong></h2>
 <p>This article is a collection of guides dedicated on explaining how to get certain structures seen all throughout Rain World &quot;just right.&quot; Anything from tips and tricks, to guides of how to make complex multi-tile machines. These guides are not limited to just vanilla Rain World, and any other unique and helpful structures are welcome to be added!</p>
-<p>&nbsp;</p>
 <h2>Sky Islands Data Boxes</h2>
 <hr />
 <p>Flashing blinking lights surrounded by kinked tubes and machines are used in a few isolated rooms in sky islands.</p>
 <h3>Basic Construction:</h3>
-<p><img src="../../assets/rwarchitecture/temp/DataboxSkyIsland_Tut1.png" referrerpolicy="no-referrer" alt="DataboxSkyIsland_Tut1"></p>
+<p><img src="../../assets/rwarchitecture/temp/DataboxSkyIsland_Tut1.png" alt="DataboxSkyIsland_Tut1" /></p>
 <p>A large rectangle of &quot;SuperStructure&quot; material. With ZeroG tube props between it and the nearest walls. Can optionally be covered by machines or cement, and then washed over with slime effect to make it slightly more rough and broken down. In game, a &quot;superStructureFuses&quot; object needs to be placed and aligned with the holes on the material to properly display the blinking lights inside the machine. Various objects and machine can be placed around it to extend the object from being a simple blinking box, into some strange machine. The rooms palette and cloud cover helps to hide the simplicity of the actual construction.</p>
-<p><img src="../../assets/rwarchitecture/temp/Databox_Tut_2.gif" referrerpolicy="no-referrer" alt="Databox_Tut_2"></p>
-<p>&nbsp;</p>
+<p><img src="../../assets/rwarchitecture/temp/Databox_Tut_2.gif" alt="Databox_Tut_2" /></p>
 <h2>Custom Shelters</h2>
 <hr />
-<p>Constructing a simple shelter for Rain World. Shelter have some specific requirements. Most can only be constructed with single doors due to how the shelter&#39;s gate will automatically latch onto the first door as a &quot;root.&quot; This guide will only be for constructing the very basics of a shelter.</p>
+<p>Constructing a simple shelter for Rain World. Shelter have some specific requirements. Most can only be constructed with single doors due to how the shelter's gate will automatically latch onto the first door as a &quot;root.&quot; This guide will only be for constructing the very basics of a shelter.</p>
 <h3>Basic Construction:</h3>
-<p><img src="../../assets/rwarchitecture/temp/Custom_shelterA.png" referrerpolicy="no-referrer" alt="Custom_shelterA"></p>
-<p>A shelter&#39;s required parts are under the shelter category in the tile editor. The dot on the shelter gate is the end that points towards the door of the shelter. This is not required however, but the dot should point away or toward the shelter, or the tunnel inside it will be rotated wrong. Only one set of locks will spawn in a shelter.</p>
-<p>The shelter&#39;s chamber only has one entrance from one of four directions. There is also a large and small variant to shelter chambers. The chamber is not required, however all vanilla shelters use these. Not placing a chamber will cause the save room to place you right against the wall opposite the door when you wake up. The shelter&#39;s lock will also start to close as soon as slugcat is no longer inside a crawlspace.</p>
-<p><img src="../../assets/rwarchitecture/temp/Custom_shelterB.png" referrerpolicy="no-referrer" alt="Custom_shelterB"></p>
+<p><img src="../../assets/rwarchitecture/temp/Custom_shelterA.png" alt="Custom_shelterA" /></p>
+<p>A shelter's required parts are under the shelter category in the tile editor. The dot on the shelter gate is the end that points towards the door of the shelter. This is not required however, but the dot should point away or toward the shelter, or the tunnel inside it will be rotated wrong. Only one set of locks will spawn in a shelter.</p>
+<p>The shelter's chamber only has one entrance from one of four directions. There is also a large and small variant to shelter chambers. The chamber is not required, however all vanilla shelters use these. Not placing a chamber will cause the save room to place you right against the wall opposite the door when you wake up. The shelter's lock will also start to close as soon as slugcat is no longer inside a crawlspace.</p>
+<p><img src="../../assets/rwarchitecture/temp/Custom_shelterB.png" alt="Custom_shelterB" /></p>
 <p>Finally, when linking your room to the region. Place a SHELTER tag at the end of the line. An example from outskirts.</p>
 <ul>
 <li>SU_S03 : SU_B01 : SHELTER</li>
 </ul>
-<p>&nbsp;</p>
 <h2>The Wall - General Style Guide</h2>
 <hr />
 <p><em>NOTICE - The Wall is a very complex and multilayered area. Experience with the editor is heavily recommended!</em></p>
-<p><img src="../../assets/rwarchitecture/temp/Walltutorial1.png" referrerpolicy="no-referrer" alt="Walltutorial1"></p>
-<p>The wall&#39;s construction is a mix of large detail tiles from &quot;The Wall&quot; category. Cooling rods are assembled out of their component pieces, usually in order of large rod segments with one or two tip segments before their cap. However oddly ordered rods can spice up the look. Rods often have poles sticking out from their caps. The bases of cooling rods are always present in single or pairs. These rods are connected directly to the wall using three &quot;Giant screw&quot; tiles from the &quot;machines&quot; category, and then connected to giant pipes traveling into the wall.</p>
+<p><img src="../../assets/rwarchitecture/temp/Walltutorial1.png" alt="Walltutorial1" /></p>
+<p>The wall's construction is a mix of large detail tiles from &quot;The Wall&quot; category. Cooling rods are assembled out of their component pieces, usually in order of large rod segments with one or two tip segments before their cap. However oddly ordered rods can spice up the look. Rods often have poles sticking out from their caps. The bases of cooling rods are always present in single or pairs. These rods are connected directly to the wall using three &quot;Giant screw&quot; tiles from the &quot;machines&quot; category, and then connected to giant pipes traveling into the wall.</p>
 <p>The Wall itself is constructed of cement, and dense pipes. Using huge pipes and other segments of the wall as spacers. The base of cooling rods can also attach to larger dome machines. These often have multiple segments of &quot;under cooler&quot; beneath them.</p>
 <p>If you need to pass between a cooling rod and the wall itself. The two segments are separated by three giant screws on each side. With huge pipes between them. Poles are used to climb between the gaps. Short cut entrances are very often wedged between wall segments, or directly attached to the tops of domes or pipes. Short cuts almost never come out from cooling rods themselves, but from the larger structures behind them.</p>
-<p>Cooling rods along the side of the wall are used as floors and ceilings to rooms. However the Wall&#39;s cooling rods never extend for more then room in width. The only segments of the wall that stick out from the wall itself are large spherical chambers with antennas on them. These will be done in a separate architecture guide.</p>
+<p>Cooling rods along the side of the wall are used as floors and ceilings to rooms. However the Wall's cooling rods never extend for more then room in width. The only segments of the wall that stick out from the wall itself are large spherical chambers with antennas on them. These will be done in a separate architecture guide.</p>
 <p>The far background of the Wall consists of thick pipes, cement, and rarely a &quot;very large beam&quot; from the &quot;metal&quot; category. The tips of these beams can be capped off with &quot;pillar beam connection&quot;s from the &quot;underhang&quot; category.</p>
-<p>The wall&#39;s materials are broken up into two segments. Certain areas having large chunks of &quot;random machines&quot; fitted with pipes. The tunnels through the machines using &quot;crawlspace&quot; tiles on top of them. Other tunnels outside of the machines use &quot;crawlhole&quot; tiles. The upper sections are dotted with &quot;Asian sign&quot; tiles. Usually mixed between dense pipes or scaffolding. These can be used to break up the color of the palette and make your walls seem less uniform. Huge chains are used as props to beak up the background itself. These are anchored to beams and the Wall&#39;s side by small blocks of &quot;random machine&quot; material.</p>
+<p>The wall's materials are broken up into two segments. Certain areas having large chunks of &quot;random machines&quot; fitted with pipes. The tunnels through the machines using &quot;crawlspace&quot; tiles on top of them. Other tunnels outside of the machines use &quot;crawlhole&quot; tiles. The upper sections are dotted with &quot;Asian sign&quot; tiles. Usually mixed between dense pipes or scaffolding. These can be used to break up the color of the palette and make your walls seem less uniform. Huge chains are used as props to beak up the background itself. These are anchored to beams and the Wall's side by small blocks of &quot;random machine&quot; material.</p>
 <p>Plant life along the wall is very scarce. Mostly being various grasses and hanging roots. The rubble effect is also used here to create a more varied ground. However, using piles of large trash or dirt can also work to break up the straight lines that the cooling rods and domes create. Grasses often grow out of these. Food is also rare on the wall. Very few segments having hanging fruits. Slime and BlackGoo effects as always help to break up the more straight and dull segments of bare materials. The underside of cooling rods are slimier then the tops. Hanging chains can also be used to help break up the background. Just be sure none of the chains connect off the edge of the screen!</p>
-<p><img src="../../assets/rwarchitecture/temp/Walltutorial2.png" referrerpolicy="no-referrer" alt="Walltutorial2"></p>
-<p>Finally. The &quot;AboveCloudsView&quot; room setting in the <a href='https://rain-world-modding.fandom.com/wiki/Dev_Tools'>dev tools</a> is used to draw the giant sea of clouds view near the upper half of the wall. This however, requires your room to be at a certain height above 0 in the <a href='https://rain-world-modding.fandom.com/wiki/Map_Tab'>Map Tab</a>&#39;s &quot;canon view.&quot; An easy method to configure this is to simply drag the first room you want this effect to appear in upwards on the map. Save, and reload the room by dying. If the effect is not far enough up the wall yet, keep going. If it is too far, move it back down until you are happy with its elevation, and then build your map off of this room&#39;s elevation.</p>
-<p>The default palette of the wall is 19, with a very slight fade to 29. EffectA is 8 and effectB is 7. A heavy fog, a light bloom, wind sounds with the wall&#39;s own unique humming sound effects complete most of the region&#39;s ambience. Don&#39;t be afraid to explore some stranger twists to the region&#39;s structure however!</p>
+<p><img src="../../assets/rwarchitecture/temp/Walltutorial2.png" alt="Walltutorial2" /></p>
+<p>Finally. The &quot;AboveCloudsView&quot; room setting in the <a href="https://rain-world-modding.fandom.com/wiki/Dev_Tools">dev tools</a> is used to draw the giant sea of clouds view near the upper half of the wall. This however, requires your room to be at a certain height above 0 in the <a href="https://rain-world-modding.fandom.com/wiki/Map_Tab">Map Tab</a>'s &quot;canon view.&quot; An easy method to configure this is to simply drag the first room you want this effect to appear in upwards on the map. Save, and reload the room by dying. If the effect is not far enough up the wall yet, keep going. If it is too far, move it back down until you are happy with its elevation, and then build your map off of this room's elevation.</p>
+<p>The default palette of the wall is 19, with a very slight fade to 29. EffectA is 8 and effectB is 7. A heavy fog, a light bloom, wind sounds with the wall's own unique humming sound effects complete most of the region's ambience. Don't be afraid to explore some stranger twists to the region's structure however!</p>
+
 </body>
 </html>

--- a/pages/region-development/Making-A-Region-From-The-Ground-Up.html
+++ b/pages/region-development/Making-A-Region-From-The-Ground-Up.html
@@ -1,45 +1,43 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
-<script src='../../scripts/extras.js'></script>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Making-A-Region-From-The-Ground-Up</title></head>
-<body><h1>Making A Region From The Ground Up</h1>
-<p>So you want to make a region, but you have no clue where to start! The idea of modding something so big is certainly daunting! However, looking at everything in small repeatable pieces will let you work step by step until one day you&#39;ll suddenly have a finished region! However before that happens you need to learn some basics to get you started! Lets start with some terminology of the tools used!</p>
+<title>Making A Region From The Ground Up (Rain World Modding)</title>
+</head>
+<body>
+<h1>Making A Region From The Ground Up</h1>
+<p>So you want to make a region, but you have no clue where to start! The idea of modding something so big is certainly daunting! However, looking at everything in small repeatable pieces will let you work step by step until one day you'll suddenly have a finished region! However before that happens you need to learn some basics to get you started! Lets start with some terminology of the tools used!</p>
 <ul>
-<li><a href='../level-editor/Official-Level-Editor.html'>Official level editor</a> - This is the tool given to the modding community by the Rain World developers. These are the actual tools used to make Rain World. However much of its features and hotkeys are difficult and quirky to work with at first, but given enough time and use, the editor becomes an extremely powerful tool.</li>
+<li><a href="../level-editor/Official-Level-Editor.html">Official level editor</a> - This is the tool given to the modding community by the Rain World developers. These are the actual tools used to make Rain World. However much of its features and hotkeys are difficult and quirky to work with at first, but given enough time and use, the editor becomes an extremely powerful tool.</li>
 <li>Unofficial level editor - This is a tool created by AndrewFM and Mikronaut to edit Rain World rooms before the official editor was released. While it lacks many features needed to make rooms. It does have the incredibly useful feature of being able to edit already exported rooms. As well as changing creature dens into doors, and vice versa.</li>
-<li><a href='https://rain-world-modding.fandom.com/wiki/Dev_Tools'>Dev Tools</a> - These are in game tools Rain World uses for editing room visual effects, sounds, and triggers. As well as the regions map, and the various other specific configurations of your room!</li>
-<li><a href='World-File-Format.html'>World File</a> - This controls how your region (or any other region!) binds rooms together. As well as creature spawns!</li>
+<li><a href="https://rain-world-modding.fandom.com/wiki/Dev_Tools">Dev Tools</a> - These are in game tools Rain World uses for editing room visual effects, sounds, and triggers. As well as the regions map, and the various other specific configurations of your room!</li>
+<li><a href="World-File-Format.html">World File</a> - This controls how your region (or any other region!) binds rooms together. As well as creature spawns!</li>
 <li>Room settings text - These files are present for every room that you save a configuration for in the dev tools. It contains the placement of objects, sounds, room effects, and any other setting applied using the dev tools.</li>
-
 </ul>
-<p>I will not be giving a full control outline for every editor in this tutorial. If you need the editor&#39;s controls, please see the full article on the specific tool you are using for their list of inputs and quirks. This article is an exercise in how to bring a level from an empty screen, to a fully fleshed out room. Largely following my own process. Don&#39;t be afraid to branch out and try weirder things as you get comfortable with the editor!</p>
-<p>&nbsp;</p>
+<p>I will not be giving a full control outline for every editor in this tutorial. If you need the editor's controls, please see the full article on the specific tool you are using for their list of inputs and quirks. This article is an exercise in how to bring a level from an empty screen, to a fully fleshed out room. Largely following my own process. Don't be afraid to branch out and try weirder things as you get comfortable with the editor!</p>
 <h2>IMPORTANT TERMS</h2>
 <hr />
 <p>Before we start. It is extremely important to understand a few things about Rain World! Even if you do not plan to make a whole region, or only want to dip your toes into modding. It is important to know these!</p>
 <ul>
 <li>The editors are used to make rooms. You will not be crafting your entire region in a single editor project. You will be making one room at a time.</li>
-<li>A region is a large collection of connected rooms. Using a <a href='World-File-Format.html'>World File</a> to setup data inside them.</li>
+<li>A region is a large collection of connected rooms. Using a <a href="World-File-Format.html">World File</a> to setup data inside them.</li>
 <li>A room is three files that control how Rain World handles the walls of that room, the graphics of that room, and finally the effects and colors of that room.</li>
-<li>The editor can only export the collision and graphics for rooms, <a href='https://rain-world-modding.fandom.com/wiki/Dev_Tools'>Dev Tools</a> are used to set the colors and effects.</li>
+<li>The editor can only export the collision and graphics for rooms, <a href="https://rain-world-modding.fandom.com/wiki/Dev_Tools">Dev Tools</a> are used to set the colors and effects.</li>
 <li>Code edits are required if you want to have passage support for your region.</li>
 <li>This guide is mostly about how to build the rooms that make up a region. As linking rooms using the world file does not take such a massive guide to explain.</li>
 <li>You will need at least a single door in your room in order to test it, as well as link it to the rest of your region later.</li>
 <li>By default, the editor will create a room the correct size for a single screen, with a single camera already setup for you. This is why the guide assumes only a single screen to help you learn to use the editor. Be default, a single room is 72 x 43.</li>
-
 </ul>
-<p>&nbsp;</p>
 <h2>Setting Up</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/1.png" referrerpolicy="no-referrer" alt="1"></p>
-<p>Once you open the official editor for the first time. you will be greeted with a file select. It is advised to make a folder for your rooms to keep them organized before you open the editor. Use the arrow keys to navigate into that folder, and press N to make a new room. You will then be greeted with the editor&#39;s main menu.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/1.png" alt="1" /></p>
+<p>Once you open the official editor for the first time. you will be greeted with a file select. It is advised to make a folder for your rooms to keep them organized before you open the editor. Use the arrow keys to navigate into that folder, and press N to make a new room. You will then be greeted with the editor's main menu.</p>
 <h3>Saving, and name quirks:</h3>
 <p>Before we do anything, lets save our room. It is REQUIRED that you start all of your rooms names with a region prefix. You can check the Rain World, World folder for the regions in game. We will be using SU_ the prefix for outskirts, at least until we have several rooms for our region later, or you are confident enough to begin making rooms for your own region.</p>
-<p>Secondly, NEVER use spaces. Always use an underscore _ to separate your name&#39;s sections. Examples of correct room names:</p>
+<p>Secondly, NEVER use spaces. Always use an underscore _ to separate your name's sections. Examples of correct room names:</p>
 <ul>
 <li>SU_test01</li>
 <li>SU_myroom</li>
@@ -47,7 +45,6 @@
 <li>SU_another_room</li>
 <li>SU_lotsandlotsofroom15</li>
 <li>SU_A04</li>
-
 </ul>
 <p>The developers often used the letter (A, B, C..., J...) after the underscore _ to track the number of cameras in the room (for non-shelter (S) rooms), but this is not required. Examples of actual rooms in the game:</p>
 <ul>
@@ -57,124 +54,106 @@
 <li>CC_D01 - tall Chimney Canopy room with 4 cameras (D)</li>
 <li>SL_F01 - Shoreline room with 6 cameras (F)</li>
 <li>UW_J01 - huge room in The Wall with 10 cameras (J)</li>
-
 </ul>
 <p>So now. You are ready to begin painting!</p>
-<p>&nbsp;</p>
 <h2>A Blank Canvas</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/2.png" referrerpolicy="no-referrer" alt="2"></p>
-<p>Click the geometry editor button to begin painting your level&#39;s basic geometry. However, before we do anything. We will first clear all the layer using the &quot;clear all&quot; tool. Use the arrow keys while the mouse is over the tile grid to change tools. Once the red box is over the X shaped tool. Used the numpad to navigate to the top left corner, click once to start drawing the rectangle of the clear tool, and navigate to the bottom right to place the other corner. When you are finished all the solid walls in the room will be removed. Leaving you with a completely blank canvas to work from.</p>
-<p>A &quot;fuzzy&quot; grey border marks the very edge of a room. Where tiles no longer exist to the game. The white rectangle is the game play border Anything outside of this will repeat off into the distance, this ONLY applies to the room&#39;s collision. Visually they will be fine. All room in Rain World use these borders. For a more simple explanation. Keep everything related to gameplay inside the white rectangle! Anything outside will only show up visually, but will not act the same as they would inside the rectangle!</p>
-<p>&nbsp;</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/2.png" alt="2" /></p>
+<p>Click the geometry editor button to begin painting your level's basic geometry. However, before we do anything. We will first clear all the layer using the &quot;clear all&quot; tool. Use the arrow keys while the mouse is over the tile grid to change tools. Once the red box is over the X shaped tool. Used the numpad to navigate to the top left corner, click once to start drawing the rectangle of the clear tool, and navigate to the bottom right to place the other corner. When you are finished all the solid walls in the room will be removed. Leaving you with a completely blank canvas to work from.</p>
+<p>A &quot;fuzzy&quot; grey border marks the very edge of a room. Where tiles no longer exist to the game. The white rectangle is the game play border Anything outside of this will repeat off into the distance, this ONLY applies to the room's collision. Visually they will be fine. All room in Rain World use these borders. For a more simple explanation. Keep everything related to gameplay inside the white rectangle! Anything outside will only show up visually, but will not act the same as they would inside the rectangle!</p>
 <h2>Blocking It Out</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/3.png" referrerpolicy="no-referrer" alt="3"></p>
-<p>Lets start painting out the shapes we want for our basic level! This seems like a bit sudden of a jump, but only a few moments of messing around in the editor will let you achieve what you see in the screenshot! Short cuts to doors and dens require walls to be placed in specific ways around them. The <a href='../level-editor/Geometry-Editor.html'>Geometry Editor</a> article goes into more depth about properly connecting short cuts, doors, and dens.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/3.png" alt="3" /></p>
+<p>Lets start painting out the shapes we want for our basic level! This seems like a bit sudden of a jump, but only a few moments of messing around in the editor will let you achieve what you see in the screenshot! Short cuts to doors and dens require walls to be placed in specific ways around them. The <a href="../level-editor/Geometry-Editor.html">Geometry Editor</a> article goes into more depth about properly connecting short cuts, doors, and dens.</p>
 <p>For now, we will simply place walls, some poles, and at least one &quot;Entrance&quot; to the room. The Dens seen in the screenshot are optional. Only one door is required for this tutorial.</p>
-<p>&nbsp;</p>
 <h2>A Test Render...</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/4.png" referrerpolicy="no-referrer" alt="4"></p>
-<p>Before we move on; Lets do another save. So if anything goes wrong we won&#39;t lose the level geometry we now have. Press 1 on the number row to return to the main menu, and press the save button! Press enter in the name field to save the room without changing the name of it. It is now time to do a test render of our room so we can see if it plays correctly in game! First, we need to click &quot;Text Output&quot; to save the levels collision data, and then press &quot;Render Level.&quot;</p>
-<p>The editor will appear to freeze for a few moments. This is normal! Do not be worried, or attempt to close the editor! Eventually the editor will begin processing each layer of the room. Before it will render the rooms data into a red and black image. The files will be output into the &quot;Levels&quot; folder by the editor&#39;s executable.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/4.png" alt="4" /></p>
+<p>Before we move on; Lets do another save. So if anything goes wrong we won't lose the level geometry we now have. Press 1 on the number row to return to the main menu, and press the save button! Press enter in the name field to save the room without changing the name of it. It is now time to do a test render of our room so we can see if it plays correctly in game! First, we need to click &quot;Text Output&quot; to save the levels collision data, and then press &quot;Render Level.&quot;</p>
+<p>The editor will appear to freeze for a few moments. This is normal! Do not be worried, or attempt to close the editor! Eventually the editor will begin processing each layer of the room. Before it will render the rooms data into a red and black image. The files will be output into the &quot;Levels&quot; folder by the editor's executable.</p>
 <p>The files ROOMNAME.txt and ROOMNAME_1.png are the exported version of your room, for use by Rain Worlds engine. Lets get to seeing our room in game!</p>
-<p>&nbsp;</p>
 <h2>Our First Link</h2>
 <hr />
-<p>For now. We will be using outskirts as a quick way to test our room. We don&#39;t have our own region yet after all! There is already an easy to use DISCONNECTED door in outskirts, close to the start of the game. Lets move our room files to where they are needed!</p>
-<p>First. Copy the ROOMNAME.txt and ROOMNAME_1.png files from the editor&#39;s level export folder. Then navigate to &quot;Rain World\World\Regions\SU\Rooms&quot;. Inside you will see various other room files, and their settings file. For now, we will simply paste our room files into this folder.</p>
-<p>Second. We will go one folder up. So we are inside the &quot;SU&quot; region folder. In here you will see Outskirt&#39;s World.txt file. The detail of this file are in this article: <a href='World-File-Format.html'>World File Format</a>. However, for the purpose of this tutorial, we will be following the next steps to install our room to Outskirts!</p>
+<p>For now. We will be using outskirts as a quick way to test our room. We don't have our own region yet after all! There is already an easy to use DISCONNECTED door in outskirts, close to the start of the game. Lets move our room files to where they are needed!</p>
+<p>First. Copy the ROOMNAME.txt and ROOMNAME_1.png files from the editor's level export folder. Then navigate to &quot;Rain World\World\Regions\SU\Rooms&quot;. Inside you will see various other room files, and their settings file. For now, we will simply paste our room files into this folder.</p>
+<p>Second. We will go one folder up. So we are inside the &quot;SU&quot; region folder. In here you will see Outskirt's World.txt file. The detail of this file are in this article: <a href="World-File-Format.html">World File Format</a>. However, for the purpose of this tutorial, we will be following the next steps to install our room to Outskirts!</p>
 <p>Third. Open World_SU.txt. Inside we will see several door connections, creature spawns, and other region related data. Look for the line:</p>
 <ul>
 <li>SU_A63 : SU_B12, SU_A37, DISCONNECTED</li>
-
 </ul>
-<p>This room has a disconnected door we can use to hook our room into easily! Lets add our room into the file! At the end of the end of the ROOMS section, but before the END ROOMS tag, add in our room&#39;s name. Followed by a : Then add SU_A63. This will link our door to SU_A63. My room&#39;s entry looks like this:</p>
+<p>This room has a disconnected door we can use to hook our room into easily! Lets add our room into the file! At the end of the end of the ROOMS section, but before the END ROOMS tag, add in our room's name. Followed by a : Then add SU_A63. This will link our door to SU_A63. My room's entry looks like this:</p>
 <ul>
 <li>SU_myroom : SU_A63</li>
-
 </ul>
 <p>We now need to make sure SU_A63 connects to our room as well! We simply need to change DISCONNECTED into our rooms name. Mine looks like:</p>
 <ul>
 <li>SU_A63 : SU_B12, SU_A37, SU_myroom</li>
-
 </ul>
-<p>We can now start Rain World! If this has all been done correctly. Then you will be able to load your file without it crashing to a grey screen. Simply navigate to SU_A63 to see the freshly added connection! You can peak into SU&#39;s &quot;Rooms&quot; folder, and find SU_A63_1.png to see what the room looks like to know where it is in game!</p>
-<p>&nbsp;</p>
+<p>We can now start Rain World! If this has all been done correctly. Then you will be able to load your file without it crashing to a grey screen. Simply navigate to SU_A63 to see the freshly added connection! You can peak into SU's &quot;Rooms&quot; folder, and find SU_A63_1.png to see what the room looks like to know where it is in game!</p>
 <h2>...Making Mistakes</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/5.png" referrerpolicy="no-referrer" alt="5"></p>
-<p>Our first room is pretty rough! Not everything will be perfect of course! This is a time to see if everything in our geometry works right! If pits are impossible to jump across, or if a jump is just a little our of reach. This is the time to tweak our level till we are happy with the layout. Render times are very fast with just a single layer and some walls after all! Don&#39;t be afraid of mistakes at this point. Just fix them and tweak until your room feels like it is playable, and there are no locations that you can become stuck in.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/5.png" alt="5" /></p>
+<p>Our first room is pretty rough! Not everything will be perfect of course! This is a time to see if everything in our geometry works right! If pits are impossible to jump across, or if a jump is just a little our of reach. This is the time to tweak our level till we are happy with the layout. Render times are very fast with just a single layer and some walls after all! Don't be afraid of mistakes at this point. Just fix them and tweak until your room feels like it is playable, and there are no locations that you can become stuck in.</p>
 <p>Repeat the steps above to edit, re-render, and re-install the room. You will no longer need to link the level to the world again! You only need to update the room files and image. You do not even need to close Rain World to test these changes. Simply dying, and returning to the room is enough to cause the room to reload for you to test the new collisions!</p>
-<p>&nbsp;</p>
 <h2>A Start To Detailing</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/6.png" referrerpolicy="no-referrer" alt="6"></p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/6.png" alt="6" /></p>
 <p>This looks like another crazy jump! But once you get used to the materials the editor gives you, the tile editor will become a playground, and you may even start designing your levels with it, and instead use the geometry editor just to compliment your tiles! It will all come to you as your understanding and comfort of the editor increases.</p>
-<p>The details I&#39;ve applied myself, have been to paint various materials in the same style Outskirts uses. Large metal plates surrounding dense pipes on corners. Concrete as the base material. The rare inclusion of pipes and machines. Along with a few things I enjoy using in my own levels. Such as large signs from the Misc category, and the insides of large pipes! The tile menu can be navigated using WASD keys. Many large tiles have a collision requirement. Holding G while clicking will automatically place the required geometry for you. This allows you to build things like pipes or complex machines without revisiting the geometry editor, or to construct rooms almost entirely out of tiles. However, you will still need to visit the geometry editor at some point for the bulk of your room&#39;s padding. Where you will paint the traditional tile &quot;materials&quot; over solid walls.</p>
+<p>The details I've applied myself, have been to paint various materials in the same style Outskirts uses. Large metal plates surrounding dense pipes on corners. Concrete as the base material. The rare inclusion of pipes and machines. Along with a few things I enjoy using in my own levels. Such as large signs from the Misc category, and the insides of large pipes! The tile menu can be navigated using WASD keys. Many large tiles have a collision requirement. Holding G while clicking will automatically place the required geometry for you. This allows you to build things like pipes or complex machines without revisiting the geometry editor, or to construct rooms almost entirely out of tiles. However, you will still need to visit the geometry editor at some point for the bulk of your room's padding. Where you will paint the traditional tile &quot;materials&quot; over solid walls.</p>
 <p>The colored dots in the picture are walls painted with a specific material. These are applied as the level is rendered! For now we are still just focusing on layer 1!</p>
-<p>&nbsp;</p>
 <h2>A Second Render</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/7.png" referrerpolicy="no-referrer" alt="7"></p>
-<p>Things are starting to come together now! We can do a second little peak at how the room plays. After all, we&#39;ve likely done some tweaks with our detailing.</p>
-<p>Something is still missing however. Using only the first layer of Rain World&#39;s rooms can only give us so much detail! This level needs some DEPTH!</p>
-<p>&nbsp;</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/7.png" alt="7" /></p>
+<p>Things are starting to come together now! We can do a second little peak at how the room plays. After all, we've likely done some tweaks with our detailing.</p>
+<p>Something is still missing however. Using only the first layer of Rain World's rooms can only give us so much detail! This level needs some DEPTH!</p>
 <h2>Depth, and the Art of Backgrounds</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/8.png" referrerpolicy="no-referrer" alt="8"></p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/8.png" alt="8" /></p>
 <p>Lets head back into the editor! In the geometry editor, use the layer tool in the bottom left to change to layer 2, and paint over the places we want to place a &quot;back wall&quot; to our room! This layer is also one that creatures can climb on. Blue lizards often do this!</p>
-<p>Some details on the first layer will also &quot;bleed&quot; into layers behind them. This happens most with the insides of pipes and large chimneys! You can see in the screenshot that I have not placed any layer 2 walls behind the pipe segments at the bottom of the room&#39;s vat area. I&#39;ve done this so that the back wall will not cover over the inside of the pipes during the render! Once you are done painting, save, export text, and do a render! Lets do another test of how our level looks!</p>
-<p>&nbsp;</p>
+<p>Some details on the first layer will also &quot;bleed&quot; into layers behind them. This happens most with the insides of pipes and large chimneys! You can see in the screenshot that I have not placed any layer 2 walls behind the pipe segments at the bottom of the room's vat area. I've done this so that the back wall will not cover over the inside of the pipes during the render! Once you are done painting, save, export text, and do a render! Lets do another test of how our level looks!</p>
 <h2>A Third Render</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/9.png" referrerpolicy="no-referrer" alt="9"></p>
-<p>Yet another render, and more to see and tweak! We can fix any mistakes easily as we go. You can also skip each rendering step, and do all the layers at once if you are confident with the editor! I&#39;ll be doing a third layer, and correcting all the issues on layer 2 by the next section. All the info you need is in the official editor&#39;s article here: <a href='../level-editor/Official-Level-Editor.html'>Official Level Editor</a>. There is also a large guide of all tiles and materials, and how they look once rendered here: <a href='https://imgur.com/a/Vz3Kk' target='_blank' class='url'>https://imgur.com/a/Vz3Kk</a></p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/9.png" alt="9" /></p>
+<p>Yet another render, and more to see and tweak! We can fix any mistakes easily as we go. You can also skip each rendering step, and do all the layers at once if you are confident with the editor! I'll be doing a third layer, and correcting all the issues on layer 2 by the next section. All the info you need is in the official editor's article here: <a href="../level-editor/Official-Level-Editor.html">Official Level Editor</a>. There is also a large guide of all tiles and materials, and how they look once rendered here: https://imgur.com/a/Vz3Kk</p>
 <p>The next steps involve tweaking, rendering, retweaking, and rerendering until you are happy with the base design of your level! Remember, that some creatures use layer 2 to climb on walls, but layer 3 is far enough in the background for nothing to interact with it! Layer 1 is solid to all creatures with few if at all exceptions. Make sure you cannot get trapped in your level!</p>
-<p>&nbsp;</p>
 <h2>Effects and You</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/10.png" referrerpolicy="no-referrer" alt="10"></p>
-<p>It&#39;s time to start painting! Now that you&#39;ve solved any issues on your tile layers, and painted yourself a background layer. You are now ready to start painting effects! Remember though. Each effect slows down the render of the level quite a bit. From now on it will begin to get more time consuming to fix mistakes in the level! Especially once you start making larger rooms! Effects are what make Rain World rooms look special. They alter, distort, and deform your tiles. Grow plants, and even alter tiles entirely! The effects editor has an example image of every effect, and its basic usage outline in this article: <a href='../level-editor/Effect-Editor'>Effects Editor</a>.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/10.png" alt="10" /></p>
+<p>It's time to start painting! Now that you've solved any issues on your tile layers, and painted yourself a background layer. You are now ready to start painting effects! Remember though. Each effect slows down the render of the level quite a bit. From now on it will begin to get more time consuming to fix mistakes in the level! Especially once you start making larger rooms! Effects are what make Rain World rooms look special. They alter, distort, and deform your tiles. Grow plants, and even alter tiles entirely! The effects editor has an example image of every effect, and its basic usage outline in this article: <a href="../level-editor/Effect-Editor">Effects Editor</a>.</p>
 <p>For the basics though! BlackGoo and Slime; These two effects are used in nearly every screen in Rain World to some degree! Slime makes every tile look slightly drippy and goopy. Like a mess has been rubbed onto them. BlackGoo forms the outer &quot;shadow&quot; of rooms. Both of these work together to make your room look less repetitive and clean!</p>
-<p>&nbsp;</p>
 <h2>Yet another rendering</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/11.png" referrerpolicy="no-referrer" alt="11"></p>
-<p>Look how far we&#39;ve come! From an empty screen with nothing. To a room that feels like it is simply missing &quot;something&quot; before it is finished! Things like the brickwork along the sides passing over the BlackGoo( It only applies itself over certain materials!) can be corrected using large junk or dirt where you would want the BlackGoo down there.</p>
-<p>You can also apply other effects till you are happy with the room. This includes everything from rubble, distortions, plants, and even daddy long leg corrupted walls! The only limits is your imagination to making effects work together, and the tiles you have to use! Once you&#39;ve applied the effects you want, and have re-rendered till the level looks right. Next up is to add some props to our room!</p>
-<p>&nbsp;</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/11.png" alt="11" /></p>
+<p>Look how far we've come! From an empty screen with nothing. To a room that feels like it is simply missing &quot;something&quot; before it is finished! Things like the brickwork along the sides passing over the BlackGoo( It only applies itself over certain materials!) can be corrected using large junk or dirt where you would want the BlackGoo down there.</p>
+<p>You can also apply other effects till you are happy with the room. This includes everything from rubble, distortions, plants, and even daddy long leg corrupted walls! The only limits is your imagination to making effects work together, and the tiles you have to use! Once you've applied the effects you want, and have re-rendered till the level looks right. Next up is to add some props to our room!</p>
 <h2>Fancy Props and Design</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/12.png" referrerpolicy="no-referrer" alt="12"></p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/12.png" alt="12" /></p>
 <p>Remember to always save and keep backups! Some editor tabs can be more fussy then others!</p>
-<p>Props are used to detail your room even further. Allowing you to place details without the grid, and at any angle and distorted shape you want! The control are outlined in the article here: <a href='https://rain-world-modding.fandom.com/wiki/Prop_Editor'>Prop Editor</a>. While this is not too complex of a section. Adding a few proper can help break the rather straight geometry normally present in Rain World&#39;s levels by giving them some more curved shapes to look at. Such as tubes and valves between containers or machines!</p>
+<p>Props are used to detail your room even further. Allowing you to place details without the grid, and at any angle and distorted shape you want! The control are outlined in the article here: <a href="https://rain-world-modding.fandom.com/wiki/Prop_Editor">Prop Editor</a>. While this is not too complex of a section. Adding a few proper can help break the rather straight geometry normally present in Rain World's levels by giving them some more curved shapes to look at. Such as tubes and valves between containers or machines!</p>
 <p>Once you are all setup, we can render and move onto using the dev tools to configure the rooms more fine details! Remember. You can always re-render and re-export a level as many times as you need. At no point does a level become impossible to edit. With the one exception of losing its project save file!</p>
-<p>&nbsp;</p>
 <h2>Dev tool configurations</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/13.png" referrerpolicy="no-referrer" alt="13"></p>
-<p>We can now move onto using the <a href='https://rain-world-modding.fandom.com/wiki/Dev_Tools'>Dev Tools</a> to configure the level&#39;s more detailed settings! Everything from the room&#39;s colors, effects, and even how the rain timer affects this room!</p>
-<p>Want a section of outskirts with some kind of lightning machine? Go ahead! Want to make a flooding cave system? It&#39;s all in here! The room&#39;s palette is not tied to the region. However most regions have &quot;templates&quot; that you can use to automatically set room settings to. Instead of needing to do each room one by one the same way. You can change anything you need to away from the template default, or click &quot;NONE&quot; beneath in the template section to use purely your own settings.</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/13.png" alt="13" /></p>
+<p>We can now move onto using the <a href="https://rain-world-modding.fandom.com/wiki/Dev_Tools">Dev Tools</a> to configure the level's more detailed settings! Everything from the room's colors, effects, and even how the rain timer affects this room!</p>
+<p>Want a section of outskirts with some kind of lightning machine? Go ahead! Want to make a flooding cave system? It's all in here! The room's palette is not tied to the region. However most regions have &quot;templates&quot; that you can use to automatically set room settings to. Instead of needing to do each room one by one the same way. You can change anything you need to away from the template default, or click &quot;NONE&quot; beneath in the template section to use purely your own settings.</p>
 <p>The rooms palette can also be configured to fade between it, and another palette. Allowing you to configure the exact colors you would need. The various effects can also be configured to use Color1 or Color2 of the effect palettes. These are used to set the colors of plants. Giant signs, and even daddy long leg corruption!</p>
-<p>Exploring the dev tools documentation will give you far more info and ideas then me directly telling you every possible situation. Remember that some objects and room settings require a reload of the room to appear! Don&#39;t forget to add sounds and some environmental ambience to flesh out your room, to make it feel like a unique location in this world!</p>
+<p>Exploring the dev tools documentation will give you far more info and ideas then me directly telling you every possible situation. Remember that some objects and room settings require a reload of the room to appear! Don't forget to add sounds and some environmental ambience to flesh out your room, to make it feel like a unique location in this world!</p>
 <p><em>A very IMPORTANT notice! Be sure to click the save button before you reload the room</em> somehow! Or your changes will be lost! All of these configurations are save to ROOMNAME_settings.txt.</p>
-<p>&nbsp;</p>
 <h2>Over and Over Again</h2>
 <hr />
-<p><img src="../../assets/regionDevelopment/regionGroundUp/14.png" referrerpolicy="no-referrer" alt="14"></p>
-<p>The process of making a full region is filled with this! Making rooms from the ground up, detailing and configuring them, before linking another room onto the chain. The only real difference is that you are doing so from the gates of your own region, instead of a small room connected to the side of outskirts! There are already a few pages of documentation related to connecting in a new region yourself! The main one can be found here: <a href='Adding-A-New-Region.html'>Adding new Regions</a>. The details of how to setup creatures and connections for the region are here: <a href='World-File-Format.html'>World File Format</a>. Finally, the dev tool&#39;s map editor for making your region properly show as a map in game is here: <a href='https://rain-world-modding.fandom.com/wiki/Map_Tab'>Map Tab</a>. I&#39;ll likely be expanding this guide at some point in the future, but for now this is the basics of how to create a room from scratch! Look through the other articles for things like: Raising the water level, setting up creature spawns, understanding doors, adding food, placing objects and plants, adding sounds and effects, specific room triggers, and the various special room settings!</p>
+<p><img src="../../assets/regionDevelopment/regionGroundUp/14.png" alt="14" /></p>
+<p>The process of making a full region is filled with this! Making rooms from the ground up, detailing and configuring them, before linking another room onto the chain. The only real difference is that you are doing so from the gates of your own region, instead of a small room connected to the side of outskirts! There are already a few pages of documentation related to connecting in a new region yourself! The main one can be found here: <a href="Adding-A-New-Region.html">Adding new Regions</a>. The details of how to setup creatures and connections for the region are here: <a href="World-File-Format.html">World File Format</a>. Finally, the dev tool's map editor for making your region properly show as a map in game is here: <a href="https://rain-world-modding.fandom.com/wiki/Map_Tab">Map Tab</a>. I'll likely be expanding this guide at some point in the future, but for now this is the basics of how to create a room from scratch! Look through the other articles for things like: Raising the water level, setting up creature spawns, understanding doors, adding food, placing objects and plants, adding sounds and effects, specific room triggers, and the various special room settings!</p>
 <p>And remember! Have fun!</p>
-<p>&nbsp;</p>
 <h2>Why Do My Rooms Crash?</h2>
 <hr />
 <p>There are multiple reasons Rain World will dislike your rooms or connections. These are a few common, and more niche reasons why the game may be crashing.</p>
 <h3>Doors outside of room bounds:</h3>
-<p>ALWAYS place every part of a short cut&#39;s path inside the room&#39;s boundary. Any short cut paths outside of it are ignored and will break the game when loaded. Crashing to a grey screen on file load.</p>
+<p>ALWAYS place every part of a short cut's path inside the room's boundary. Any short cut paths outside of it are ignored and will break the game when loaded. Crashing to a grey screen on file load.</p>
 <h3>Accidental Doors and Dens:</h3>
 <p>The editor is a strange tool. It also has a second cursor in geometry mode... for some reason. An accidental key press may have placed a den, short cut entrance, or other kind of door in the room without proper connections. Take a peak over your room for any issues.</p>
 <h3>Incorrect Region Prefix:</h3>
-<p>the prefix at the start of a room file should match the region you are placing it inside. For this guide we focus on tests rooms inside of outskirts ( SU_ ). If you are bringing these rooms to a custom region by renaming them, be sure to open the room&#39;s data file, and edit the first line to match the renamed version of the file.</p>
+<p>the prefix at the start of a room file should match the region you are placing it inside. For this guide we focus on tests rooms inside of outskirts ( SU_ ). If you are bringing these rooms to a custom region by renaming them, be sure to open the room's data file, and edit the first line to match the renamed version of the file.</p>
+
 </body>
 </html>

--- a/pages/region-development/World-File-Format.html
+++ b/pages/region-development/World-File-Format.html
@@ -1,138 +1,187 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
-<script src='../../scripts/extras.js'></script>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>World-File-Format</title></head>
-<body><h1>World File Format</h1>
-<p><img src="../../assets/regionDevelopment/regionFormat.png" referrerpolicy="no-referrer" alt="regionFormat"></p>
+<title>World File Format (Rain World Modding)</title>
+</head>
+<body>
+<h1>World File Format</h1>
+<p><img src="../../assets/regionDevelopment/regionFormat.png" alt="regionFormat" /></p>
 <p>The world_XX.txt file is present in every region Rain World loads, and determines various room settings such as their pipe connections, the spawns of enemies, and specific flags like shelters and gates. Creature spawns only happen the first time you enter the region on a file, so tweaking creature spawn points requires a save that has never entered the region, or a fresh file entirely.</p>
 <p>Likewise, adding new maps to a region or changing map interconnections can break the spawn locations of creatures in an existing save file. When broken, the devtools map will show creatures bounding around in tight circles. To fix this, <strong>use a fresh save after adding any maps to a region or changing connections</strong>. Going to a shelter and starting the next cycle will work fine.</p>
-<p>&nbsp;</p>
 <h2>Room Connections</h2>
 <hr />
-<p>&nbsp;</p>
 <p>Room connections fall between the tags ROOMS and ENDROOMS. These control which pipe entrance leads to what room, and vice versa. Unique room flags that specify certain attributes about the room (such as if it is a shelter or a gate room) are set here as well. The format is as follows:</p>
-<blockquote><p>ROOM : door0, door1, door2, etc : FLAG</p>
+<blockquote>
+<p>ROOM : door0, door1, door2, etc : FLAG</p>
 </blockquote>
-<p>&nbsp;</p>
 <h3>Examples include:</h3>
 <p>A standard room with two room-connecting pipes. These will form the bulk of your region.</p>
-<blockquote><p>TR_T07 : TR_T01, TR_P02</p>
+<blockquote>
+<p>TR_T07 : TR_T01, TR_P02</p>
 </blockquote>
-<p>A standard room, with five doors. However, pipes 1, 2 and 3 have no connection. Each pipe inside a room has a specific number starting from 0. These can be viewed using the <a href='https://rain-world-modding.fandom.com/wiki/Dev_Tools'>Dev Tool&#39;s</a> <a href='https://rain-world-modding.fandom.com/wiki/Map_Tab'>Map Tab</a>, or by entering the room with dev tools enabled and pressing M.</p>
-<blockquote><p>TR_W19 : TR_L05, DISCONNECTED, DISCONNECTED, DISCONNECTED, TR_W18</p>
+<p>A standard room, with five doors. However, pipes 1, 2 and 3 have no connection. Each pipe inside a room has a specific number starting from 0. These can be viewed using the <a href="https://rain-world-modding.fandom.com/wiki/Dev_Tools">Dev Tool's</a> <a href="https://rain-world-modding.fandom.com/wiki/Map_Tab">Map Tab</a>, or by entering the room with dev tools enabled and pressing M.</p>
+<blockquote>
+<p>TR_W19 : TR_L05, DISCONNECTED, DISCONNECTED, DISCONNECTED, TR_W18</p>
 </blockquote>
 <p>A shelter. These rooms will often be copied from other regions when you are first learning how to make a region. All vanilla save rooms have a single door.</p>
-<blockquote><p>TR_S01 : TR_P01 : SHELTER</p>
+<blockquote>
+<p>TR_S01 : TR_P01 : SHELTER</p>
 </blockquote>
-<p>A region gate. Doors on the other side of the gate are set to DISCONNECTED. They will automatically be shown as connected doors due to the gate&#39;s special flags. If you need to show a save room door specifically on the other side of the gate. You can use the ExitSymbolShelter object, in the dev tool&#39;s <a href='https://rain-world-modding.fandom.com/wiki/Objects_Tab'>object tab</a> to change the door symbols as required.</p>
-<blockquote><p>GATE_SS_TR : DISCONNECTED, TR_L07 : GATE</p>
+<p>A region gate. Doors on the other side of the gate are set to DISCONNECTED. They will automatically be shown as connected doors due to the gate's special flags. If you need to show a save room door specifically on the other side of the gate. You can use the ExitSymbolShelter object, in the dev tool's <a href="https://rain-world-modding.fandom.com/wiki/Objects_Tab">object tab</a> to change the door symbols as required.</p>
+<blockquote>
+<p>GATE_SS_TR : DISCONNECTED, TR_L07 : GATE</p>
 </blockquote>
-<p>A swarm room allows batflies to spawn in the room, as long as the map contains bat nests. If the room has bat nests but is not marked as a swarm room, those nests will always be inactive. The dev tool&#39;s map tab provides the options needed to control where they will migrate and rooms they will avoid.</p>
-<blockquote><p>SU_A06 : SU_A39, SU_A36, SU_A38 : SWARMROOM</p>
+<p>A swarm room allows batflies to spawn in the room, as long as the map contains bat nests. If the room has bat nests but is not marked as a swarm room, those nests will always be inactive. The dev tool's map tab provides the options needed to control where they will migrate and rooms they will avoid.</p>
+<blockquote>
+<p>SU_A06 : SU_A39, SU_A36, SU_A38 : SWARMROOM</p>
 </blockquote>
 <p>A scavenger outpost. Wip....</p>
-<blockquote><p>SU_C02 : SU_A45, SU_A07 : SCAVOUTPOST</p>
+<blockquote>
+<p>SU_C02 : SU_A45, SU_A07 : SCAVOUTPOST</p>
 </blockquote>
-<p>&nbsp;</p>
 <h3>Understanding door connections:</h3>
-<p><img src="../../assets/regionDevelopment/regionFormatConnection.png" referrerpolicy="no-referrer" alt="regionFormatConnection"></p>
-<p>For a door to be properly connected, both ends must point to each other using valid doors. For this example, both rooms will have two doors. Door0 will be on the left, and door1 on the right. Door numbers are decided specifically for your room, so be sure to check in game how your doors have been assigned by the <a href='../level-editor/Official-Level-Editor.html'>Official Level Editor</a>. The dev tool&#39;s <a href='https://rain-world-modding.fandom.com/wiki/Map_Tab'>Map Tab</a> can also be used to see the links between doors. As in the picture to the right. Properly connected doors will show both lines pointing to the set door on the other end. Doors with incorrect links will point off to the bottom right (A disconnected door will also do this,) and a door connected to another room, but that room has no door back( or lacks enough doors! ) will point to the center of the room on the map tab page.</p>
-<blockquote><p>RG_ROOM1 : DISCONNECTED, RG_ROOM2</p>
+<p><img src="../../assets/regionDevelopment/regionFormatConnection.png" alt="regionFormatConnection" /></p>
+<p>For a door to be properly connected, both ends must point to each other using valid doors. For this example, both rooms will have two doors. Door0 will be on the left, and door1 on the right. Door numbers are decided specifically for your room, so be sure to check in game how your doors have been assigned by the <a href="../level-editor/Official-Level-Editor.html">Official Level Editor</a>. The dev tool's <a href="https://rain-world-modding.fandom.com/wiki/Map_Tab">Map Tab</a> can also be used to see the links between doors. As in the picture to the right. Properly connected doors will show both lines pointing to the set door on the other end. Doors with incorrect links will point off to the bottom right (A disconnected door will also do this,) and a door connected to another room, but that room has no door back( or lacks enough doors! ) will point to the center of the room on the map tab page.</p>
+<blockquote>
+<p>RG_ROOM1 : DISCONNECTED, RG_ROOM2</p>
 </blockquote>
-<blockquote><p>RG_ROOM2: RG_ROOM1</p>
+<blockquote>
+<p>RG_ROOM2: RG_ROOM1</p>
 </blockquote>
 <p>Room1 will have its right hand door connected to Room2. Because of this, we need to use DISCONNECTED as a placeholder for its left hand door, door0. Then set door1 to connect to Room2</p>
 <p>Room2 will connect to Room1 using door0. Due to this, we do not need to define the right hand door. It will assume it to be disconnected.</p>
-<p>&nbsp;</p>
 <h3>Room Tags:</h3>
 <p>Room tags assign certain properties to rooms depending on what the tag is. Tags are assigned like</p>
-<blockquote><p>[ROOM] : [CONNECTIONS] : [TAG]</p>
+<blockquote>
+<p>[ROOM] : [CONNECTIONS] : [TAG]</p>
 </blockquote>
 <p>Example:</p>
-<blockquote><p>SU_A06 : SU_A39, SU_A36, SU_A38 : SWARMROOM</p>
+<blockquote>
+<p>SU_A06 : SU_A39, SU_A36, SU_A38 : SWARMROOM</p>
 </blockquote>
-<figure><table>
+<table>
 <thead>
-<tr><th style='text-align:left;' ><strong><u>Tag</u></strong></th><th style='text-align:left;' ><strong><u>Function</u></strong></th></tr></thead>
-<tbody><tr><td style='text-align:left;' >&nbsp;</td><td style='text-align:left;' >&nbsp;</td></tr><tr><td style='text-align:left;' >SHELTER</td><td style='text-align:left;' >Makes the room a shelter. When there are multiple pipes in the room: the animated door is placed at the bottom right most pipe.</td></tr><tr><td style='text-align:left;' >GATE</td><td style='text-align:left;' >Makes the room a gate. Entrances on the other side of the gate are set to DISCONNECTED, and are shown automatically to be connected.</td></tr><tr><td style='text-align:left;' >SWARMROOM</td><td style='text-align:left;' >Allows batflies to be spawned from batfly hives.</td></tr><tr><td style='text-align:left;' >PERF_HEAVY</td><td style='text-align:left;' >Makes rooms run better by simplifying certain processes. (This needs expansion/further explanation)</td></tr><tr><td style='text-align:left;' >SCAVOUTPOST</td><td style='text-align:left;' >Makes the room into a scavenger outpost. Scavs will spawn here and only let you pass if you have a pearl. The outpost is controlled by the &quot;ScavengerOutpost&quot; devtools object.</td></tr><tr><td style='text-align:left;' >SCAVTRADER</td><td style='text-align:left;' >Spawns a scavenger merchant into the room. Will trade items with you. The merchant is controlled by the &quot;TradeOutpost&quot; devtools object.</td></tr></tbody>
-</table></figure>
-<p>&nbsp;</p>
+<tr>
+  <th style="text-align:left"><strong><u>Tag</u></strong></th>
+  <th style="text-align:left"><strong><u>Function</u></strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td style="text-align:left"></td>
+  <td style="text-align:left"></td>
+</tr>
+<tr>
+  <td style="text-align:left">SHELTER</td>
+  <td style="text-align:left">Makes the room a shelter. When there are multiple pipes in the room: the animated door is placed at the bottom right most pipe.</td>
+</tr>
+<tr>
+  <td style="text-align:left">GATE</td>
+  <td style="text-align:left">Makes the room a gate. Entrances on the other side of the gate are set to DISCONNECTED, and are shown automatically to be connected.</td>
+</tr>
+<tr>
+  <td style="text-align:left">SWARMROOM</td>
+  <td style="text-align:left">Allows batflies to be spawned from batfly hives.</td>
+</tr>
+<tr>
+  <td style="text-align:left">PERF_HEAVY</td>
+  <td style="text-align:left">Makes rooms run better by simplifying certain processes. (This needs expansion/further explanation)</td>
+</tr>
+<tr>
+  <td style="text-align:left">SCAVOUTPOST</td>
+  <td style="text-align:left">Makes the room into a scavenger outpost. Scavs will spawn here and only let you pass if you have a pearl. The outpost is controlled by the &quot;ScavengerOutpost&quot; devtools object.</td>
+</tr>
+<tr>
+  <td style="text-align:left">SCAVTRADER</td>
+  <td style="text-align:left">Spawns a scavenger merchant into the room. Will trade items with you. The merchant is controlled by the &quot;TradeOutpost&quot; devtools object.</td>
+</tr>
+</tbody>
+</table>
 <h3>Important quirks to rooms and doors:</h3>
-<p>When setting up your region, be sure that you always use your region&#39;s prefix to help each room have a unique name. If not, Rain World will treat repeated names as being other rooms, and even re-use rooms from other region folders entirely. If you don&#39;t use your region prefix, changes made with devtools can also wind up getting saved to unexpected places. To avoid these problems, always prefix your room with its region code, and give them unique names.</p>
+<p>When setting up your region, be sure that you always use your region's prefix to help each room have a unique name. If not, Rain World will treat repeated names as being other rooms, and even re-use rooms from other region folders entirely. If you don't use your region prefix, changes made with devtools can also wind up getting saved to unexpected places. To avoid these problems, always prefix your room with its region code, and give them unique names.</p>
 <p>Multiple pipes in a room may all go to the same room. However, these will all act like a single pipe, and you will not be able to set the specific destination pipes. There are no cases in vanilla Rain World where multiple pipes in the current room lead to the same next room. They will all lead to separate rooms. For example, if you had four pipes leading from one room to another. you would need to create a minimum of three unique rooms for each of the other pipes to act as an interconnection. TL;DR A room should not have multiple pipes leading to the same next room. Unless you expect to use this odd behavior to your advantage... such as four pipes in one room leading to a single exit in another, but returning only taking you to one of those entrances.</p>
-<p>&nbsp;</p>
 <h2>Creature Spawns</h2>
 <hr />
-<p>Creature spawn data exists between CREATURES and END CREATURES tags. Most regions also use // for comments about the creatures or for separating the difficulties into specific sections. These comments however, do nothing to the code, and can even be used in the room connections above. Rainworld only spawns creatures the moment you enter a region for the first time, or after an excessive number of cycles has passed. To properly test enemy spawns, you will need to use a fresh file, or to backup a save just before you entered the region. Editing the region while it has &quot;stale&quot; enemy data, will result in bizarre situations, such as enemies spawning in shelters, or changing their pipes to be in different rooms. These can be corrected simply by reverting to the backed up save before you entered the region, or wiping the file and re-entering the region. A full article on enemy spawns is available here: <a href='https://rain-world-modding.fandom.com/wiki/Creature_Spawns'>Creature Spawns</a>. The basic format is as follows:</p>
-<blockquote><p>(optional difficulty)ROOM : PIPE_NUMBER-ENEMY-{optional flags}-COUNT</p>
+<p>Creature spawn data exists between CREATURES and END CREATURES tags. Most regions also use // for comments about the creatures or for separating the difficulties into specific sections. These comments however, do nothing to the code, and can even be used in the room connections above. Rainworld only spawns creatures the moment you enter a region for the first time, or after an excessive number of cycles has passed. To properly test enemy spawns, you will need to use a fresh file, or to backup a save just before you entered the region. Editing the region while it has &quot;stale&quot; enemy data, will result in bizarre situations, such as enemies spawning in shelters, or changing their pipes to be in different rooms. These can be corrected simply by reverting to the backed up save before you entered the region, or wiping the file and re-entering the region. A full article on enemy spawns is available here: <a href="https://rain-world-modding.fandom.com/wiki/Creature_Spawns">Creature Spawns</a>. The basic format is as follows:</p>
+<blockquote>
+<p>(optional difficulty)ROOM : PIPE_NUMBER-ENEMY-{optional flags}-COUNT</p>
 </blockquote>
 <p>While this appears very complex, some examples will make it easier to understand, as not all entries and flags are required. The optional difficulties are 0 = normal, 1 = easy, 2 = hard.</p>
-<p>&nbsp;</p>
 <h3>Examples include:</h3>
 <p>A single green lizard, spawning from pipe 2, on all difficulties.</p>
-<blockquote><p>SU_A10 : 2-Green</p>
+<blockquote>
+<p>SU_A10 : 2-Green</p>
 </blockquote>
 <p>A single red lizard, spawning from pipe 3, on hard mode only.</p>
-<blockquote><p>(2)SU_A10 : 3-Red</p>
+<blockquote>
+<p>(2)SU_A10 : 3-Red</p>
 </blockquote>
 <p>A hoard of 5 yellow lizards spawning from pipe 1, on easy mode only.</p>
-<blockquote><p>(1)SU_A10 : 1-Yellow-5</p>
+<blockquote>
+<p>(1)SU_A10 : 1-Yellow-5</p>
 </blockquote>
 <p>A Daddy longlegs spawning from pipe 4, but only on easy and normal difficulties.</p>
-<blockquote><p>(0,1)SU_A10 : 4-Daddy</p>
+<blockquote>
+<p>(0,1)SU_A10 : 4-Daddy</p>
 </blockquote>
-<p>A very angry white lizard that spawns from pipe 3, on all difficulties. the &quot;Mean&quot; flag can be set from 0 to 1, and will change the enemy&#39;s personality to pursue you aggressively depending on how high it is set.</p>
-<blockquote><p>SU_A10 : 3-White-{Mean:0.9}</p>
+<p>A very angry white lizard that spawns from pipe 3, on all difficulties. the &quot;Mean&quot; flag can be set from 0 to 1, and will change the enemy's personality to pursue you aggressively depending on how high it is set.</p>
+<blockquote>
+<p>SU_A10 : 3-White-{Mean:0.9}</p>
 </blockquote>
 <p>Some enemies require a unique room known as OFFSCREEN. These enemies use special doors that are automatically added to your level to move between rooms. These include vultures, scavengers, leviathans, and miros birds. This example spawns two off screen vultures.</p>
-<blockquote><p>OFFSCREEN : 0-Vulture-2</p>
+<blockquote>
+<p>OFFSCREEN : 0-Vulture-2</p>
 </blockquote>
 <p>Enemy flags still apply to offscreen enemies. This will spawn a very aggressive KingVulture that will rarely leave the screen if it spots slugcat, but only on hardmode.</p>
-<blockquote><p>(2)OFFSCREEN : 0-KingVulture-{Mean:1}</p>
+<blockquote>
+<p>(2)OFFSCREEN : 0-KingVulture-{Mean:1}</p>
 </blockquote>
-<p>&nbsp;</p>
 <h3>Important quirks to creatures:</h3>
 <p>Enemies may be set to spawn from the same nest pipes. However, do not be surprised if they somehow kill each other offscreen very quickly if you do this. A daddy long legs may have no problems consuming an entire hoard of yellow lizards for example.</p>
 <p>Enemies will often drag you back to their home nest pipes, but may also choose other pipes they like, even in different rooms.</p>
 <p>During the end of a cycle, almost every enemy will rush to a nearby nest, if they spawned from it or not.</p>
 <p>Many creatures that would not intuitively appear to nest in pipes, likely does so, you just never reach them before they spawn in game, or their pipes are well hidden. A direct example of this, is that wandering daddy longlegs spawn from pipes, and return to their pipes before the end of a cycle. This includes the daddies inside Five Pebbles, which makes the area significantly easier once the cycle timer has counted down entirely.</p>
 <p>It is important to understand various enemy interactions to help you build a cohesive and believable ecosystem for an area. Sandbox mode can help you learn which creature is where on the food chain. As well as looking at the interactions of creatures in other regions.</p>
-<p>Some creatures have very specific requirements for rooms they inhabit. A very game breaking example, is that big spiders and spitting spiders require the ability to reach every wall in a room in some fashion. By pole, or by invisible ceilings out of the camera. If they cannot, the game will lag very badly due to the spider&#39;s failed pathfinding.</p>
+<p>Some creatures have very specific requirements for rooms they inhabit. A very game breaking example, is that big spiders and spitting spiders require the ability to reach every wall in a room in some fashion. By pole, or by invisible ceilings out of the camera. If they cannot, the game will lag very badly due to the spider's failed pathfinding.</p>
 <p>Some creatures have a heavier performance impact on the game then others. Sandbox mode can help you learn these, as it will show a notice that &quot;too many of this creature will impact performance&quot; when you begin to place too many. An example is that more then 4 daddy long legs on screen will often lead to lag. Unfortunate development gets around this problem by using the &quot;stuckDaddy&quot; object, as these daddies do not run wandering path finding checks.</p>
-<p>All enemies can be configured using the dev tool&#39;s map editor to prefer, avoid, stay or be forbidden inside certain rooms while wandering. These spawn entries are simply where they will be created from when the player first enters a region.</p>
-<p>&nbsp;</p>
+<p>All enemies can be configured using the dev tool's map editor to prefer, avoid, stay or be forbidden inside certain rooms while wandering. These spawn entries are simply where they will be created from when the player first enters a region.</p>
 <h2>Creature Spawns(Lineage System)</h2>
 <hr />
 <p>Enemy nests may also be configured to use the lineage system. After being killed, this allows a creature to roll a dice at the end of a cycle, and in a certain percent, respawn as its next entry in the lineage. Due to the format however, you cannot decide how many enemies can spawn from the pipe. So a green lizard cannot turn into a hoard of 3 yellow lizards. Only a single yellow lizard. Enemy flags, and difficulty filters still apply however. The format is as follows:</p>
-<blockquote><p>LINEAGE : ROOM : PIPE : STARTENEMY-PERCENT, NEXTENEMY-PERCENT, FINALENEMY-0</p>
+<blockquote>
+<p>LINEAGE : ROOM : PIPE : STARTENEMY-PERCENT, NEXTENEMY-PERCENT, FINALENEMY-0</p>
 </blockquote>
 <p>PERCENT is a value between 0 and 1, and is the percent chance that the enemy will move onto its next form. You may have as many forms as you need. However, it is important to ALWAYS mark the last enemy in the lineage with a 0 percent chance to move on. Rain World will likely crash the moment it attempts to move to the next enemy in a lineage from the last, or display undefined behavior.</p>
-<p>&nbsp;</p>
 <h3>Examples include:</h3>
 <p>A green lizard that spawns from pipe 2, that turns into a blue, and then into a red. With a 5% chance each time.</p>
-<blockquote><p>LINEAGE : SU_B08 : 2 : Green-0.05, Blue-0.05, Red-0</p>
+<blockquote>
+<p>LINEAGE : SU_B08 : 2 : Green-0.05, Blue-0.05, Red-0</p>
 </blockquote>
 <p>A poleplant, with a specific height of 10 blocks, and spawning from pipe 3. That has a 10% chance to turn into a monster kelp</p>
-<blockquote><p>LINEAGE : SU_A02 : 3 : Mimic-{10}-0.1, TentaclePlant-0</p>
+<blockquote>
+<p>LINEAGE : SU_A02 : 3 : Mimic-{10}-0.1, TentaclePlant-0</p>
 </blockquote>
 <p>A empty pipe 3, that has a 1% chance to turn into a monster kelp.</p>
-<blockquote><p>LINEAGE : SU_B02 : 3 : NONE-0.01, TentaclePlant-0</p>
+<blockquote>
+<p>LINEAGE : SU_B02 : 3 : NONE-0.01, TentaclePlant-0</p>
 </blockquote>
 <p>Lineage applies to offscreen creatures, as well as difficulties! This example from chimney canopy has a 20% chance to turn a vulture into a king vulture after being killed, but only on normal difficulty.</p>
-<blockquote><p>(0)LINEAGE : OFFSCREEN : 0 : Vulture-0.2, KingVulture-0</p>
-<p>&nbsp;</p>
+<blockquote>
+<p>(0)LINEAGE : OFFSCREEN : 0 : Vulture-0.2, KingVulture-0</p>
 </blockquote>
 <h2>Bat Migration Blockages</h2>
 <hr />
 <p>Bat migration blockages exist between BAT MIGRATION BLOCKAGES and END BAT MIGRATION BLOCKAGES tags. These are used specifically to prevent bat flies from entering a room, or pathing through the region to rooms on the other side of it. These are rarely used. However the room directly after the tutorial area in outskirts is set to be one. The format is simply to list each room line by line between the two tags. There are no unique flags.</p>
 <p>For the example in Outskirts, bat flies cannot enter room SU_A22 because it is between the tags:</p>
-<blockquote><p>BAT MIGRATION BLOCKAGES</p>
+<blockquote>
+<p>BAT MIGRATION BLOCKAGES</p>
 <p>SU_A22</p>
 <p>END BAT MIGRATION BLOCKAGES</p>
 </blockquote>
+
 </body>
 </html>

--- a/pages/using-mods/BepInEx.html
+++ b/pages/using-mods/BepInEx.html
@@ -1,38 +1,37 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>BepInEx</title></head>
-<body><h1>BepInEx</h1>
-<p>BepInEx is a plugin framework primarily for Unity games. In the Rain World modding community, we are migrating to a modified version of BepInEx (from the Partiality launcher, which is now abandonware). </p>
-<p><strong>Very important note:</strong> the generic BepInEx releases are not directly compatible with Rain World / RW&#39;s old Partiality mods. It is imperative you use modified Rain World BepInEx for support with the majority of existing Rain World mods (information current on 29th Dec 2020).</p>
-<p>RW BepInEx can currently be downloaded from <a href='https://drive.google.com/file/d/1WcCCsS3ABBdO1aX-iJGeqeE07YE4Qv88/view'>here</a>. </p>
-<p>The following video tutorial made by LeeMoriya explains how to install both RW BepInEx and BOI (see below), as well as the additional steps required to migrate from Partiality to BepInEx if applicable) - <a href='https://youtu.be/brDN_8uN6-U' target='_blank' class='url'>https://youtu.be/brDN_8uN6-U</a> .</p>
+<title>BepInEx (Rain World Modding)</title>
+</head>
+<body>
+<h1>BepInEx</h1>
+<p>BepInEx is a plugin framework primarily for Unity games. In the Rain World modding community, we are migrating to a modified version of BepInEx (from the Partiality launcher, which is now abandonware).</p>
+<p><strong>Very important note:</strong> the generic BepInEx releases are not directly compatible with Rain World / RW's old Partiality mods. It is imperative you use modified Rain World BepInEx for support with the majority of existing Rain World mods (information current on 29th Dec 2020).</p>
+<p>RW BepInEx can currently be downloaded from <a href="https://drive.google.com/file/d/1WcCCsS3ABBdO1aX-iJGeqeE07YE4Qv88/view">here</a>.</p>
+<p>The following video tutorial made by LeeMoriya explains how to install both RW BepInEx and BOI (see below), as well as the additional steps required to migrate from Partiality to BepInEx if applicable) - https://youtu.be/brDN_8uN6-U .</p>
 <hr />
 <h2>Differences from Partiality</h2>
 <p><em>Partiality is a deprecated mod launcher that used to be the primary mod loader for the Rain World modding community. It served us well, but now BepInEx is here as a superior alternative.</em></p>
 <h3>BOI Interface</h3>
-<p>BepInEx doesn&#39;t have a graphical user interface (or GUI - the app with buttons and such). Obviously this is a little tedious, as users would be required to move mod DLLs between folders themselves... This is where thalber&#39;s BlepOutIn (or BOI) launcher comes in. BOI is an app that provides a nice interface for RW BepInEx, as well as some other related tools such as easy access to Extended Dev Tools settings and region pack settings.</p>
-<p><img src="https://rain-world-modding.github.io/rain-world-modding/assets/BOI-main.png" referrerpolicy="no-referrer" alt="BOI"></p>
-<p>You can find the release page for BOI <a href='https://github.com/thalber/BOI/releases/latest'>here</a>. </p>
-<p>&nbsp;</p>
+<p>BepInEx doesn't have a graphical user interface (or GUI - the app with buttons and such). Obviously this is a little tedious, as users would be required to move mod DLLs between folders themselves... This is where thalber's BlepOutIn (or BOI) launcher comes in. BOI is an app that provides a nice interface for RW BepInEx, as well as some other related tools such as easy access to Extended Dev Tools settings and region pack settings.</p>
+<p><img src="https://rain-world-modding.github.io/rain-world-modding/assets/BOI-main.png" alt="BOI" /></p>
+<p>You can find the release page for BOI <a href="https://github.com/thalber/BOI/releases/latest">here</a>.</p>
 <h3>Increased stability</h3>
 <p>The BepInEx part of RW BepInEx has been tested by a community far larger than Rain World, as it is used for many other Unity games. This means that it is more reliable and stable than Partiality. In addition, future bugs found in BepInEx and BOI will likely be addressed promptly, whereas Partiality is abandoned and will receive no widespread support.</p>
-<p>&nbsp;</p>
 <h3>Ability to run BepInPlugins</h3>
-<p>BepInPlugins, as the name suggests, are plugins made for BepInEx. Simply put, they won&#39;t run on Partiality. As of 29th Dec 2020, only one BepInPlugin has been released, but it&#39;s inevitable that more will come (this excludes the BepInPlugins used within RW BepInEx itself). </p>
+<p>BepInPlugins, as the name suggests, are plugins made for BepInEx. Simply put, they won't run on Partiality. As of 29th Dec 2020, only one BepInPlugin has been released, but it's inevitable that more will come (this excludes the BepInPlugins used within RW BepInEx itself).</p>
 <p>As mentioned at the top of the article, RW BepInEx supports the use of Partiality mods.</p>
-<p>&nbsp;</p>
 <hr />
 <h2>Replacement of Publicity Stunt</h2>
 <p>Publicity Stunt [link to pubstunt page] was discovered to cause issues when using BepInEx. This caused two issues that have now both been addressed...</p>
 <h3>Referencing private members</h3>
-<p>To reference private members of the game&#39;s code, <a href='https://beestuff.pythonanywhere.com/audb/api/mods/0/21/download/latest'>download GeneratePublicAssembly.dll</a> , place it in <code>Rain World/BepInEx/patchers</code> , and run the game using RW BepInEx. A modified version of <code>Assembly-CSharp.dll</code> should appear in the root Rain World folder with its private members made public. <em>Do not distribute this - this is for your own use.</em> </p>
+<p>To reference private members of the game's code, <a href="https://beestuff.pythonanywhere.com/audb/api/mods/0/21/download/latest">download GeneratePublicAssembly.dll</a> , place it in <code>Rain World/BepInEx/patchers</code> , and run the game using RW BepInEx. A modified version of <code>Assembly-CSharp.dll</code> should appear in the root Rain World folder with its private members made public. <em>Do not distribute this - this is for your own use.</em></p>
 <h3>Accessing private members during gameplay</h3>
-<p>The file <code>Dragons.PublicDragon</code> distributed with RW BepInEx deals with the seemingly random interaction of BepInEx and pubstunt by patching all mod assemblies with some code that tells them to ignore access modifiers. Because of this,  even if your mod requires access to the game&#39;s private members, end users are not required to do anything beyond using your mod with RW BepInEx to allow this.</p>
-<p>&nbsp;</p>
+<p>The file <code>Dragons.PublicDragon</code> distributed with RW BepInEx deals with the seemingly random interaction of BepInEx and pubstunt by patching all mod assemblies with some code that tells them to ignore access modifiers. Because of this,  even if your mod requires access to the game's private members, end users are not required to do anything beyond using your mod with RW BepInEx to allow this.</p>
+
 </body>
 </html>

--- a/pages/utility-mods/EnumExtender.html
+++ b/pages/utility-mods/EnumExtender.html
@@ -1,21 +1,17 @@
-﻿<!DOCTYPE html>
-<html>
+﻿<!doctype html>
+<html lang='en'>
 <head>
-<link rel='stylesheet' href='../../css/article.css'/>
 <link rel='stylesheet' href='../../css/main.css'/>
-    <link rel='stylesheet' href='../../css/main.css' />
-    <link rel='stylesheet' href='../../css/article.css' />
-    <script src='../../scripts/extras.js'></script>
-    <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width initial-scale=1'>
-    <title>EnumExtender</title>
+<link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
+<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
+<title>EnumExtender (Rain World Modding)</title>
 </head>
 <body>
-
-    <h1 id="enumextender">EnumExtender</h1>
+<h1>EnumExtender</h1>
 <p><a href="https://beestuff.pythonanywhere.com/audb/api/mods/0/1/download/latest">EnumExtender</a> is a tool mod by bee, which allows you to add more items in <code>enum</code>s much easier.</p>
 <hr />
-<h2 id="how-to-use">How to Use</h2>
+<h2>How to Use</h2>
 <p>First, create a <code>public static class</code> with a name starts with <code>EnumExt_</code>.
 EnumExtender will automatically detect any class in your assembly with that keyword.
 Then create a field with the type of enum you want to extend, and item name for the field name.</p>
@@ -75,7 +71,6 @@ This can be used to detect whether EnumExtender is installed or not.</p>
 }
 </code></pre>
 <p>That's about it. This mod is really easy to use and understand, but as many things in Rain World is set in <code>enum</code>s, having an ability to edit them grants so much potential.</p>
-
 
 </body>
 </html>

--- a/pages/utility-mods/RegionCast.html
+++ b/pages/utility-mods/RegionCast.html
@@ -1,32 +1,31 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>RegionCast</title></head>
-<body><h1>RegionCast</h1>
-<p>RegionCast is a <a href='https://rain-world-modding.github.io/rain-world-modding/pages/creating-mods/BepInPlugins.html'>BepInPlugin</a> and side-app combo created by casheww that adds Discord Rich Presence to Rain World. The Rich Presence details the player&#39;s current location, the game mode, and the time elapsed from when they started that game mode. It also supports customisation from region pack creators and custom slugcat creators [hyperlinks to relevant pages] . </p>
-<p>The latest release of RegionCast can be found <a href='https://github.com/casheww/RW-RegionCast/releases/latest'>here</a> - be sure to read the README for installation instructions. </p>
-<p><img src="../../assets/regioncast/regcast-sporecat.png" referrerpolicy="no-referrer" alt="RegionCast demo"></p>
-<p>&nbsp;</p>
+<title>RegionCast (Rain World Modding)</title>
+</head>
+<body>
+<h1>RegionCast</h1>
+<p>RegionCast is a <a href="https://rain-world-modding.github.io/rain-world-modding/pages/creating-mods/BepInPlugins.html">BepInPlugin</a> and side-app combo created by casheww that adds Discord Rich Presence to Rain World. The Rich Presence details the player's current location, the game mode, and the time elapsed from when they started that game mode. It also supports customisation from region pack creators and custom slugcat creators [hyperlinks to relevant pages] .</p>
+<p>The latest release of RegionCast can be found <a href="https://github.com/casheww/RW-RegionCast/releases/latest">here</a> - be sure to read the README for installation instructions.</p>
+<p><img src="../../assets/regioncast/regcast-sporecat.png" alt="RegionCast demo" /></p>
 <hr />
 <h2>Customisation for other modders</h2>
 <h3>Custom Region names</h3>
-<p>By default, RegionCast will use the (sub)region names already specified by the game (the ones read from the region&#39;s <code>Properties.txt</code> file). However, by installing a region with Garrakx&#39;s CRS [hyperlink when page exists] and adding a simple file, this can be overridden. Reasons to do this may include preventing spoilers for your region pack appearing in players&#39; or region developers&#39; Rich Presence, or shortening the name of a location that would otherwise be cut off by Discord&#39;s character limit.</p>
+<p>By default, RegionCast will use the (sub)region names already specified by the game (the ones read from the region's <code>Properties.txt</code> file). However, by installing a region with Garrakx's CRS [hyperlink when page exists] and adding a simple file, this can be overridden. Reasons to do this may include preventing spoilers for your region pack appearing in players' or region developers' Rich Presence, or shortening the name of a location that would otherwise be cut off by Discord's character limit.</p>
 <ol>
-<li>Navigate to <code>Rain World/Mods/CustomResources/&lt;region-pack-name&gt;/World/Regions/&lt;region-code&gt;/</code> and add a file called <code>RegionCast.txt</code>. </li>
+<li>Navigate to <code>Rain World/Mods/CustomResources/&lt;region-pack-name&gt;/World/Regions/&lt;region-code&gt;/</code> and add a file called <code>RegionCast.txt</code>.</li>
 <li>For each of the location names your wish to change, add a line in the new file with the format <code>region-name:name-to-display</code>- e.g.: <code>Underbelly:Soggy Place</code> would display &quot;Soggy Place&quot; when the location would otherwise be called &quot;Underbelly&quot; (assuming the file location is correct).</li>
-
 </ol>
-<p>&nbsp;</p>
 <h3>Custom Region thumbnails</h3>
-<p>Due to the way Discord handles Rich Presence assets, the only way for a region pack to receive region thumbnail support is by submitting through casheww. An GitHub issue may be submitted for this using <a href='https://github.com/casheww/RW-RegionCast/issues/new?assignees=casheww&amp;labels=custom+region+req&amp;template=custom-region-request.md&amp;title=Custom+Region+%3A+%5BRegion+name%5D'>this issue template</a>. A list of the custom regions with custom thumbnail support on RegionCast can be found <a href='https://casheww.github.io/RW-RegionCast/'>here</a>. </p>
-<p>&nbsp;</p>
+<p>Due to the way Discord handles Rich Presence assets, the only way for a region pack to receive region thumbnail support is by submitting through casheww. An GitHub issue may be submitted for this using <a href="https://github.com/casheww/RW-RegionCast/issues/new?assignees=casheww&amp;labels=custom+region+req&amp;template=custom-region-request.md&amp;title=Custom+Region+%3A+%5BRegion+name%5D">this issue template</a>. A list of the custom regions with custom thumbnail support on RegionCast can be found <a href="https://casheww.github.io/RW-RegionCast/">here</a>.</p>
 <h3>Custom Slugcat names</h3>
 <p>Note: <em>this section refers to mods that add a new slugcat to the game, not those that just modify sprite atlases or overwrite existing character slots.</em></p>
 <p>Everyone loves slugcats!
-In the game&#39;s story mode, RegionCast reads and uses <code>Menu.SlugcatSelectMenu.SlugcatPage.colorName</code> to display on the Rich Presence. This is done from a hook to <code>Menu.SlugcatSelectMenu.SlugcatPage.Singal</code> if the... <em>singal</em> message is &quot;START&quot;, signifying that the gameplay is about to be loaded - RegionCast stores the <code>colorName</code> for later use.</p>
+In the game's story mode, RegionCast reads and uses <code>Menu.SlugcatSelectMenu.SlugcatPage.colorName</code> to display on the Rich Presence. This is done from a hook to <code>Menu.SlugcatSelectMenu.SlugcatPage.Singal</code> if the... <em>singal</em> message is &quot;START&quot;, signifying that the gameplay is about to be loaded - RegionCast stores the <code>colorName</code> for later use.</p>
+
 </body>
 </html>

--- a/pages/utility-mods/Warp.html
+++ b/pages/utility-mods/Warp.html
@@ -1,30 +1,31 @@
 <!doctype html>
-<html>
+<html lang='en'>
 <head>
 <link rel='stylesheet' href='../../css/main.css'/>
 <link rel='stylesheet' href='../../css/article.css'/>
 <script src='../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
-<title>Warp</title></head>
-<body><h1>Warp</h1>
+<title>Warp (Rain World Modding)</title>
+</head>
+<body>
+<h1>Warp</h1>
 <p>Warp is a utility mod for Rain World that you can use to easily teleport Slugcat to different rooms and regions, this is particularly useful for testing mods and custom regions.</p>
-<p>Download and install Warp from <a href='https://www.raindb.net'>RainDB&#39;s</a> &#39;Tools&#39; section or it&#39;s <a href='https://github.com/LeeMoriya/Warp'>GitHub</a> page.</p>
+<p>Download and install Warp from <a href="https://www.raindb.net">RainDB's</a> 'Tools' section or it's <a href="https://github.com/LeeMoriya/Warp">GitHub</a> page.</p>
 <h2>Usage</h2>
 <p>Install Warp using BepInEx for RW or Partiality, the Warp menu will appear in the pause menu in-game.</p>
-<p>A list of rooms in the current region will be displayed on the right, a list of installed regions will appear in the top left, and gate rooms in the bottom left. Simply click on a room name to warp slugcat to that room. They will be placed at the room&#39;s first pipe entrance, labelled 0.</p>
-<p>Clicking on a different region than the one you are currently in will load a list of all the rooms in that region, allowing you to warp there without the use of gates. This process may take a few seconds depending on the size of the region being loaded. </p>
+<p>A list of rooms in the current region will be displayed on the right, a list of installed regions will appear in the top left, and gate rooms in the bottom left. Simply click on a room name to warp slugcat to that room. They will be placed at the room's first pipe entrance, labelled 0.</p>
+<p>Clicking on a different region than the one you are currently in will load a list of all the rooms in that region, allowing you to warp there without the use of gates. This process may take a few seconds depending on the size of the region being loaded.</p>
 <h3>Issues When Warping</h3>
-<p>If the region doesn&#39;t load then there is likely an issue with the region or room you are trying to Warp to. Check your <em>exceptionLog.txt</em> for errors and review any recent changes you made. If you are making a custom region make sure that there are no errors with room connections in your World file, or problems with your room&#39;s geometry, like pipe entrances. </p>
+<p>If the region doesn't load then there is likely an issue with the region or room you are trying to Warp to. Check your <em>exceptionLog.txt</em> for errors and review any recent changes you made. If you are making a custom region make sure that there are no errors with room connections in your World file, or problems with your room's geometry, like pipe entrances.</p>
 <p>If you have installed a new region make sure you have started the game from a fresh save since that region was added or the game may freeze when switching regions or resting in a shelter.</p>
 <h2>Custom Den Position</h2>
-<p>Warp features an option you change which room the game considers as Slugcat&#39;s &#39;Den Position&#39; -- the room they start in that cycle. Note that if you are using Extended Dev Tools, the &#39;Start Map&#39; parameter in the edtSetup.json must be empty or it will overwrite Warp.</p>
+<p>Warp features an option to change which room the game considers as Slugcat's 'Den Position' -- the room they start in that cycle. Note that if you are using Extended Dev Tools, the 'Start Map' parameter in the edtSetup.json must be empty or it will overwrite Warp.</p>
 <ul>
 <li>Hold Shift and click a room name to set the den position.</li>
 <li>Press C to reset the den position to its default.</li>
-
 </ul>
 <h2>Custom Regions Support</h2>
-<p>Warp supports Garrakx&#39;s Custom Regions Support mod which allows for easier creation of new regions and region changes, and will load new rooms from within your CustomResources folder. Below is how room lists are currently generated:</p>
+<p>Warp supports Garrakx's Custom Regions Support mod which allows for easier creation of new regions and region changes, and will load new rooms from within your CustomResources folder. Below is how room lists are currently generated:</p>
 <h3>Current Region</h3>
 <p>The list of rooms for the region you are currently in are taken directly from the list of loaded AbstractRooms.</p>
 <h3>Different Regions</h3>
@@ -32,9 +33,9 @@
 <ol>
 <li>Rooms are added to the room list from the vanilla World folder.</li>
 <li>Each Rooms folder found in CustomResources is scanned and rooms not already in the list are added.</li>
-
 </ol>
-<p>At the moment, this means that if a region pack is present in your CustomResources folder but has been manually disabled in it&#39;s regionInfo.json, rooms from this folder will be added regardless and clicking on them will do nothing.</p>
-<p>This is also technically the case for any region pack that <em>removes</em> rooms, though I don&#39;t know of any that do.</p>
+<p>At the moment, this means that if a region pack is present in your CustomResources folder but has been manually disabled in it's regionInfo.json, rooms from this folder will be added regardless and clicking on them will do nothing.</p>
+<p>This is also technically the case for any region pack that <em>removes</em> rooms, though I don't know of any that do.</p>
+
 </body>
 </html>

--- a/pages/utility-mods/config-machine/GeneratedOI.html
+++ b/pages/utility-mods/config-machine/GeneratedOI.html
@@ -1,9 +1,9 @@
 ﻿<!doctype html>
 <html lang='en'>
 <head>
-<link rel='stylesheet' href='../../css/main.css'/>
-<link rel='stylesheet' href='../../css/article.css'/>
-<script src='../../scripts/extras.js'></script>
+<link rel='stylesheet' href='../../../css/main.css'/>
+<link rel='stylesheet' href='../../../css/article.css'/>
+<script src='../../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
 <title>GeneratedOI (Rain World Modding)</title>
 </head>

--- a/pages/utility-mods/config-machine/GeneratedOI.html
+++ b/pages/utility-mods/config-machine/GeneratedOI.html
@@ -1,19 +1,17 @@
-﻿<!DOCTYPE html>
-<html>
+﻿<!doctype html>
+<html lang='en'>
 <head>
-<script src='../../../scripts/extras.js'></script>
-<link rel='stylesheet' href='../../../css/article.css'/>
-<link rel='stylesheet' href='../../../css/main.css'/>
-    <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width initial-scale=1'>
-    <title>GeneratedOI</title>
+<link rel='stylesheet' href='../../css/main.css'/>
+<link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
+<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
+<title>GeneratedOI (Rain World Modding)</title>
 </head>
 <body>
-
-    <h1 id="generatedoi">GeneratedOI</h1>
+<h1>GeneratedOI</h1>
 <p><code>GeneratedOI</code> is a child class of <code>OptionInterface</code> that helps generating fixed-format GUI with less effort.</p>
 <hr />
-<h2 id="displaying-basic-profile">Displaying Basic Profile</h2>
+<h2>Displaying Basic Profile</h2>
 <p>Simply inheriting <code>GeneratedOI</code> instead of <code>OptionInterface</code> works.
 This does make your mod dependent to Config Machine,
 and Config Machine generates GUI to display the basic information of your mod without this dependency.
@@ -21,7 +19,7 @@ So this is only useful when you're using OptionInterface for other features, lik
 <pre><code class="language-c#">public class MyOI : GeneratedOI
 {
     private const string desc = &quot;Changes this thing and that thing&quot;;
-    
+
     public MyOI() : base(plugin: MyPlugin.instance, desc)
     { transFile = &quot;MyPlugin.Translation.txt&quot;; }
 }
@@ -36,12 +34,12 @@ if you have <code>OpScrollBox</code> replacing <code>OpTab</code>.</p>
     base.Initialize();
     Tabs = new OpTab[] { new OpTab() };
     GeneratedOI.AddBasicProfile(Tabs[0], rwMod);
-    
+
     Tabs[0].AddItems(new OpCheckBox(100f, 350f, &quot;EnableStuff&quot;, false) { description = &quot;Enables this stuff&quot; });
 }
 </code></pre>
 <hr />
-<h2 id="bepinex.configuration">BepInEx.Configuration</h2>
+<h2>BepInEx.Configuration</h2>
 <p>If you only need to have few configurable like simple <code>bool</code>s and you don't need special design for your GUI,
 you can simply use <code>BepInEx.Configuration</code> which is BepInEx's native configuration support.
 This generates a cfg file in <code>BepInEx/config</code> folder,
@@ -75,83 +73,22 @@ void Awake()
 <pre><code class="language-c#">if (cfgCheck.Value)
 { Logger.LogMessage(cfgText.Value); }
 </code></pre>
-<h3 id="acceptable-types">Acceptable Types</h3>
+<h3>Acceptable Types</h3>
 <p>As of Config Machine <code>v1.5.1</code>, it accepts the following types and uses provided UIconfig.
 (Height is the pixel height that how much this ConfigEntry would use.
 And each entry get 20 pixeled gaps in between)</p>
-<table>
-<thead>
-<tr>
-<th style="text-align: right;">type</th>
-<th style="text-align: center;">UIconfig</th>
-<th style="text-align: right;">Height</th>
-<th style="text-align: left;">Note</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="text-align: right;">bool</td>
-<td style="text-align: center;">OpCheckBox</td>
-<td style="text-align: right;">60</td>
-<td style="text-align: left;"></td>
-</tr>
-<tr>
-<td style="text-align: right;">byte</td>
-<td style="text-align: center;">OpSliderSubtle</td>
-<td style="text-align: right;">90</td>
-<td style="text-align: left;">Range: [0, 20]</td>
-</tr>
-<tr>
-<td style="text-align: right;">uint</td>
-<td style="text-align: center;">OpSlider</td>
-<td style="text-align: right;">90</td>
-<td style="text-align: left;">Range: [0, 100]</td>
-</tr>
-<tr>
-<td style="text-align: right;">int</td>
-<td style="text-align: center;">OpTextBox</td>
-<td style="text-align: right;">60</td>
-<td style="text-align: left;">Accepts: Int</td>
-</tr>
-<tr>
-<td style="text-align: right;">float</td>
-<td style="text-align: center;">OpTextBox</td>
-<td style="text-align: right;">60</td>
-<td style="text-align: left;">Accepts: Float</td>
-</tr>
-<tr>
-<td style="text-align: right;">string(Hex)</td>
-<td style="text-align: center;">OpColorPicker</td>
-<td style="text-align: right;">170</td>
-<td style="text-align: left;">When defaultValue is Hex</td>
-</tr>
-<tr>
-<td style="text-align: right;">string</td>
-<td style="text-align: center;">OpTextBox</td>
-<td style="text-align: right;">60</td>
-<td style="text-align: left;">When defaultValue is not Hex; Accepts: ASCII</td>
-</tr>
-<tr>
-<td style="text-align: right;">KeyCode</td>
-<td style="text-align: center;">OpKeyBinder</td>
-<td style="text-align: right;">100</td>
-<td style="text-align: left;"></td>
-</tr>
-<tr>
-<td style="text-align: right;">enumType</td>
-<td style="text-align: center;">OpResourceSelector</td>
-<td style="text-align: right;">60</td>
-<td style="text-align: left;"></td>
-</tr>
-<tr>
-<td style="text-align: right;">default</td>
-<td style="text-align: center;">N/A</td>
-<td style="text-align: right;"></td>
-<td style="text-align: left;">Will warn the user that this plugin has ConfigEntry that's not supported by Config Machine</td>
-</tr>
-</tbody>
-</table>
-
+<p>|type           |UIconfig	            |Height |Note	|
+|---:	        |:---:	                |---:	|:---	|
+|bool           |OpCheckBox             |60     | |
+|byte           |OpSliderSubtle         |90     |Range: [0, 20]   |
+|uint           |OpSlider               |90     |Range: [0, 100]   |
+|int            |OpTextBox              |60     |Accepts: Int  |
+|float          |OpTextBox              |60     |Accepts: Float   |
+|string(Hex)    |OpColorPicker          |170    |When defaultValue is Hex   |
+|string         |OpTextBox              |60     |When defaultValue is not Hex; Accepts: ASCII   |
+|KeyCode        |OpKeyBinder            |100    |   |
+|enumType       |OpResourceSelector     |60     |   |
+|default        |N/A                    |       |Will warn the user that this plugin has ConfigEntry that's not supported by Config Machine   |</p>
 
 </body>
 </html>

--- a/pages/utility-mods/config-machine/OptionInterface.html
+++ b/pages/utility-mods/config-machine/OptionInterface.html
@@ -1,20 +1,18 @@
-﻿<!DOCTYPE html>
-<html>
+﻿<!doctype html>
+<html lang='en'>
 <head>
-<script src='../../../scripts/extras.js'></script>
-<link rel='stylesheet' href='../../../css/article.css'/>
-<link rel='stylesheet' href='../../../css/main.css'/>
-    <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width initial-scale=1'>
-    <title>OptionInterface</title>
+<link rel='stylesheet' href='../../css/main.css'/>
+<link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
+<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
+<title>OptionInterface (Rain World Modding)</title>
 </head>
 <body>
-
-    <h1 id="optioninterface">OptionInterface</h1>
+<h1>OptionInterface</h1>
 <p>To interact with Config Machine, it is best to have a child class of <code>OptionInterface</code>.
 This means your mod will be <em>dependent</em> with Config Machine.</p>
 <hr />
-<h2 id="creating-optioninterface-class">Creating OptionInterface class</h2>
+<h2>Creating OptionInterface class</h2>
 <p>First download <a href="https://drive.google.com/file/d/1NIE8conaoI1OOHevi4K9tvOG4v-NIfYf/view">Config Machine</a> from RainDB,
 extract the zip and put both dll and xml in the folder where you store References.
 Then add <code>ConfigMachine.dll</code> to References of your mod project.
@@ -28,7 +26,7 @@ Create a new cs file and make a class inheriting <code>OptionInterface</code>.</
 <p>Now add <code>LoadOI</code> static method in your <code>BaseUnityPlugin</code> class that returns your OptionInterface.</p>
 <pre><code class="language-c#">public static OptionInterface LoadOI() =&gt; return new MyOI();
 </code></pre>
-<h3 id="designing-gui">Designing GUI</h3>
+<h3>Designing GUI</h3>
 <p>For designing your GUI, using <a href="https://inkscape.org/">Inkscape</a> is strongly suggested.
 With Inkscape, create a file with 600 x 600 pixel, then enable [View] - [Canvas Orientation] - [Flip Vertically].
 (Alternatively, you can use any CAD program which has up and right as positive axis by default)</p>
@@ -49,7 +47,7 @@ If you're using Inkscape with [Flip Vertically] setting on, you can get those fr
 <li>You don't have to put everything in a single <code>OpTab</code>. If the canvas gets crowded, disperse your items for easier readability.</li>
 <li>Try to avoid using smaller <code>OpScrollBox</code>s to store many things in one place even if that's an option: The users cannot see everything in a single screen which reduces usability greatly.</li>
 </ul>
-<h3 id="initialize">Initialize</h3>
+<h3>Initialize</h3>
 <p><code>OptionInterface.Initialize</code> is called in IntroRoll(for loading configuration) and ConfigMenu(for displaying to users).
 You can check whether Initialize is called in ConfigMenu or not with <code>OptionInterface.isOptionMenu</code>.
 It usually goes like this following example:</p>
@@ -60,7 +58,7 @@ It usually goes like this following example:</p>
     Tabs[0] = new OpTab(&quot;Main&quot;); // Each OpTab is 600 x 600 pixel sized canvas
     Tabs[1] = new OpTab(&quot;Second&quot;)
     { color = Color.cyan }; // You can change its button and canvas colour too
-    
+
     // After Initializing Tabs, create UIelements
 }
 </code></pre>
@@ -87,7 +85,7 @@ Cosmetic UIconfig is useful when you want to have provided <code>UIconfig</code>
 When the user activates an <code>UItrigger</code> in some way, it will call the <code>Signal</code> function in OptionInterface which will be explained later.</p>
 <pre><code class="language-c#">    Tabs[0].AddItems(new OpSimpleButton(new Vector2(400f, 200f), new Vector2(100f, 24f), &quot;press&quot;, &quot;Press Me&quot;));
 </code></pre>
-<h3 id="update">Update</h3>
+<h3>Update</h3>
 <p><code>Update</code> function is called every frame when the game is in ConfigMenu, and this OptionInterface is currently active
 (The user has currently selected this mod from the list on left).
 This is useful to make reactive GUI, especially since each <code>UIconfig</code> instance can have only one value saved.
@@ -100,7 +98,7 @@ public override void Initialize()
 {
     base.Initialize();
     Tabs = new OpTab[] { new OpTab() };
-    
+
     select = 0;
     rbgSelect = new OpRadioButtonGroup(&quot;_&quot;, select);
     Tabs[0].AddItems(rbgSelect);
@@ -134,7 +132,7 @@ public override void Update(float dt)
     }
 }
 </code></pre>
-<h3 id="configonchange">ConfigOnChange</h3>
+<h3>ConfigOnChange</h3>
 <p><code>ConfigOnChange</code> is called whenever <code>config</code> Dictionary is updated,
 mainly when Config Machine loads OptionInterfaces in IntroRoll,
 and when the user saves changes of configuration in ConfigMenu.
@@ -150,7 +148,7 @@ The following is an example of how to convert a string value to the correspondin
     MyMod.config.myColor = OpColorPicker.HexToColor(config[&quot;keyColor&quot;]);
 }
 </code></pre>
-<h3 id="signal">Signal</h3>
+<h3>Signal</h3>
 <p><code>Signal</code> is called when the user has interacted with <code>UItrigger</code>.
 Override this for reaction to that.</p>
 <pre><code class="language-c#">public override void Signal(UItrigger trigger, string signal)
@@ -166,7 +164,6 @@ Override this for reaction to that.</p>
 <hr />
 <p>That's about the basics on how to use OptionInterface.
 For farther detail about <a href="Provided-UIelements.html">provided UIelements</a> or <a href="Translation-Support.html">Translation API</a>, continue reading those pages.</p>
-
 
 </body>
 </html>

--- a/pages/utility-mods/config-machine/OptionInterface.html
+++ b/pages/utility-mods/config-machine/OptionInterface.html
@@ -1,9 +1,9 @@
 ﻿<!doctype html>
 <html lang='en'>
 <head>
-<link rel='stylesheet' href='../../css/main.css'/>
-<link rel='stylesheet' href='../../css/article.css'/>
-<script src='../../scripts/extras.js'></script>
+<link rel='stylesheet' href='../../../css/main.css'/>
+<link rel='stylesheet' href='../../../css/article.css'/>
+<script src='../../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
 <title>OptionInterface (Rain World Modding)</title>
 </head>

--- a/pages/utility-mods/config-machine/Provided-UIelements.html
+++ b/pages/utility-mods/config-machine/Provided-UIelements.html
@@ -1,9 +1,9 @@
 ﻿<!doctype html>
 <html lang='en'>
 <head>
-<link rel='stylesheet' href='../../css/main.css'/>
-<link rel='stylesheet' href='../../css/article.css'/>
-<script src='../../scripts/extras.js'></script>
+<link rel='stylesheet' href='../../../css/main.css'/>
+<link rel='stylesheet' href='../../../css/article.css'/>
+<script src='../../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
 <title>Provided UIelements (Rain World Modding)</title>
 </head>

--- a/pages/utility-mods/config-machine/Provided-UIelements.html
+++ b/pages/utility-mods/config-machine/Provided-UIelements.html
@@ -1,14 +1,14 @@
-﻿<!DOCTYPE html>
-<html>
+﻿<!doctype html>
+<html lang='en'>
 <head>
-<script src='../../../scripts/extras.js'></script>
-<link rel='stylesheet' href='../../../css/article.css'/>
-<link rel='stylesheet' href='../../../css/main.css'/>
-    <title>Provided UIelements [WIP]</title>
+<link rel='stylesheet' href='../../css/main.css'/>
+<link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
+<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
+<title>Provided UIelements (Rain World Modding)</title>
 </head>
 <body>
-
-    <h1 id="provided-uielements-wip">Provided UIelements [WIP]</h1>
+<h1>Provided UIelements [WIP]</h1>
 <p>This page is up to date with Config Machine <code>v1.5.1</code>.</p>
 <p>This page explains what each provided <code>UIelement</code> is and how to use them.
 You can check out the source code of Config Machine from its <a href="https://github.com/metnias/CompletelyOptional">github page</a>,
@@ -19,65 +19,64 @@ The list of those follows:</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">UIelement</th>
-<th style="text-align: right;">width</th>
-<th style="text-align: right;">height</th>
+  <th style="text-align:left">UIelement</th>
+  <th style="text-align:right">width</th>
+  <th style="text-align:right">height</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">OpCheckBox</td>
-<td style="text-align: right;">24</td>
-<td style="text-align: right;">24</td>
+  <td style="text-align:left">OpCheckBox</td>
+  <td style="text-align:right">24</td>
+  <td style="text-align:right">24</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpRadioButton</td>
-<td style="text-align: right;">24</td>
-<td style="text-align: right;">24</td>
+  <td style="text-align:left">OpRadioButton</td>
+  <td style="text-align:right">24</td>
+  <td style="text-align:right">24</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpDragger</td>
-<td style="text-align: right;">24</td>
-<td style="text-align: right;">24</td>
+  <td style="text-align:left">OpDragger</td>
+  <td style="text-align:right">24</td>
+  <td style="text-align:right">24</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpSlider</td>
-<td style="text-align: right;">*<em>30</em></td>
-<td style="text-align: right;"></td>
+  <td style="text-align:left">OpSlider</td>
+  <td style="text-align:right">*<em>30</em></td>
+  <td style="text-align:right"></td>
 </tr>
 <tr>
-<td style="text-align: left;">OpSliderSubtle</td>
-<td style="text-align: right;">*<em>30</em></td>
-<td style="text-align: right;"></td>
+  <td style="text-align:left">OpSliderSubtle</td>
+  <td style="text-align:right">*<em>30</em></td>
+  <td style="text-align:right"></td>
 </tr>
 <tr>
-<td style="text-align: left;">OpComboBox</td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;">24</td>
+  <td style="text-align:left">OpComboBox</td>
+  <td style="text-align:right"></td>
+  <td style="text-align:right">24</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpColorPicker</td>
-<td style="text-align: right;">150</td>
-<td style="text-align: right;">150</td>
+  <td style="text-align:left">OpColorPicker</td>
+  <td style="text-align:right">150</td>
+  <td style="text-align:right">150</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpTextBox</td>
-<td style="text-align: right;"></td>
-<td style="text-align: right;">24</td>
+  <td style="text-align:left">OpTextBox</td>
+  <td style="text-align:right"></td>
+  <td style="text-align:right">24</td>
 </tr>
 <tr>
-<td style="text-align: left;">OpHoldButton</td>
-<td style="text-align: right;">rad:</td>
-<td style="text-align: right;"><em>55</em></td>
+  <td style="text-align:left">OpHoldButton</td>
+  <td style="text-align:right">rad:</td>
+  <td style="text-align:right"><em>55</em></td>
 </tr>
 </tbody>
 </table>
 <p>(* The width perpendicular to its length is fixed)</p>
 <hr />
-<h2 id="table-of-contents">Table of Contents</h2>
+<h2>Table of Contents</h2>
 <ol>
-<li><a href="##UIelement">UIelement</a>
-<ol>
+<li><a href="##UIelement">UIelement</a><ol>
 <li><a href="###OpLabel">OpLabel</a> &amp; <a href="####OpLabelLong">OpLabelLong</a></li>
 <li><a href="###OpRect">OpRect</a></li>
 <li><a href="###OpImage">OpImage</a></li>
@@ -85,8 +84,7 @@ The list of those follows:</p>
 <li><a href="###OpContainer">OpContainer</a></li>
 </ol>
 </li>
-<li><a href="##UIconfig">UIconfig</a>
-<ol>
+<li><a href="##UIconfig">UIconfig</a><ol>
 <li><a href="###OpCheckBox">OpCheckBox</a></li>
 <li><a href="###OpRadioButtonGroup">OpRadioButtonGroup</a> &amp; <a href="####OpRadioButton">OpRadioButton</a></li>
 <li><a href="###OpDragger">OpDragger</a></li>
@@ -97,14 +95,12 @@ The list of those follows:</p>
 <li><a href="###OpTextBox">OpTextBox</a></li>
 </ol>
 </li>
-<li><a href="##UItrigger">UItrigger</a>
-<ol>
+<li><a href="##UItrigger">UItrigger</a><ol>
 <li><a href="###OpSimpleButton">OpSimpleButton</a> &amp; <a href="####OpSimpleImageButton">OpSimpleImageButton</a></li>
 <li><a href="###OpHoldButton">OpHoldButton</a></li>
 </ol>
 </li>
-<li><a href="##Custom-Classes">Custom Classes</a>
-<ol>
+<li><a href="##Custom-Classes">Custom Classes</a><ol>
 <li><a href="###DyeableRect">DyeableRect</a></li>
 <li><a href="###BumpBehaviour">BumpBehaviour</a></li>
 <li><a href="###FTexture">FTexture</a></li>
@@ -115,7 +111,7 @@ The list of those follows:</p>
 </li>
 </ol>
 <hr />
-<h2 id="uielement">UIelement</h2>
+<h2>UIelement</h2>
 <p>UIelement is everything that can be added in <code>OpTab</code>, which is 600x600 canvas.
 Its sub-categories are <a href="##UIconfig">UIconfig</a> and <a href="##UItrigger">UItrigger</a>.
 UIelement can be either rectangular(pos and size) or circular(pos and rad),
@@ -124,326 +120,326 @@ although the vast majority of provided UIelements are rectangular.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;"><em>pos(setter)</em></td>
-<td style="text-align: left;">Sets bottom-left position <em>relative</em> to its canvas (<code>OpTab</code>/<code>OpScrollBox</code>).</td>
+  <td style="text-align:left"><em>pos(setter)</em></td>
+  <td style="text-align:left">Sets bottom-left position <em>relative</em> to its canvas (<code>OpTab</code>/<code>OpScrollBox</code>).</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>size</em></td>
-<td style="text-align: left;">The size of the element. (When this is rectangular)</td>
+  <td style="text-align:left"><em>size</em></td>
+  <td style="text-align:left">The size of the element. (When this is rectangular)</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>rad</em></td>
-<td style="text-align: left;">The radius of the element. (When this is circular)</td>
+  <td style="text-align:left"><em>rad</em></td>
+  <td style="text-align:left">The radius of the element. (When this is circular)</td>
 </tr>
 <tr>
-<td style="text-align: left;">description</td>
-<td style="text-align: left;">Infotext that will be shown at the bottom of the screen when MouseOver is true.</td>
+  <td style="text-align:left">description</td>
+  <td style="text-align:left">Infotext that will be shown at the bottom of the screen when MouseOver is true.</td>
 </tr>
 <tr>
-<td style="text-align: left;">MouseOver</td>
-<td style="text-align: left;">Whether the mouse cursor is over this element.</td>
+  <td style="text-align:left">MouseOver</td>
+  <td style="text-align:left">Whether the mouse cursor is over this element.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">Hide()</td>
-<td style="text-align: left;">Hides this UIelement, and prevent interaction.</td>
+  <td style="text-align:left">Hide()</td>
+  <td style="text-align:left">Hides this UIelement, and prevent interaction.</td>
 </tr>
 <tr>
-<td style="text-align: left;">Show()</td>
-<td style="text-align: left;">Unhide this UIelement.</td>
+  <td style="text-align:left">Show()</td>
+  <td style="text-align:left">Unhide this UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">GetPos()</td>
-<td style="text-align: left;">Returns bottom-left position <em>relative</em> to its canvas (<code>OpTab</code>/<code>OpScrollBox</code>). (pos(getter) returns <em>absolute</em> position)</td>
+  <td style="text-align:left">GetPos()</td>
+  <td style="text-align:left">Returns bottom-left position <em>relative</em> to its canvas (<code>OpTab</code>/<code>OpScrollBox</code>). (pos(getter) returns <em>absolute</em> position)</td>
 </tr>
 <tr>
-<td style="text-align: left;">Reset()</td>
-<td style="text-align: left;">Reset this UIelement if it's possible.</td>
+  <td style="text-align:left">Reset()</td>
+  <td style="text-align:left">Reset this UIelement if it's possible.</td>
 </tr>
 <tr>
-<td style="text-align: left;">FrameMultiply(origFrameCount)</td>
-<td style="text-align: left;">(static) When you have a frame counter in Update, use this to accommodate with Many More Fixes' FPS unlock feature.</td>
+  <td style="text-align:left">FrameMultiply(origFrameCount)</td>
+  <td style="text-align:left">(static) When you have a frame counter in Update, use this to accommodate with Many More Fixes' FPS unlock feature.</td>
 </tr>
 <tr>
-<td style="text-align: left;">DTMultiply(deltaTime)</td>
-<td style="text-align: left;">(static) Without MMF's FPS meddling, this returns somewhere close to <code>1f</code>. Use this for ticking gradual changes.</td>
+  <td style="text-align:left">DTMultiply(deltaTime)</td>
+  <td style="text-align:left">(static) Without MMF's FPS meddling, this returns somewhere close to <code>1f</code>. Use this for ticking gradual changes.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="oplabel">OpLabel</h3>
+<h3>OpLabel</h3>
 <p><img src="../../../assets/configmachine/provided/Label.png" alt="OpLabel Sample" /></p>
 <p>Simply displays text.</p>
 <p>(<em>Italic</em> parameters are optional)</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Displays text aligned to defined rectangular</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Displays text aligned to defined rectangular</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">size</td>
-<td style="text-align: left;">Width and height of the rectangle this UIelement occupies.</td>
+  <td style="text-align:left">size</td>
+  <td style="text-align:left">Width and height of the rectangle this UIelement occupies.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>text</em></td>
-<td style="text-align: left;">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
+  <td style="text-align:left"><em>text</em></td>
+  <td style="text-align:left">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>alignment</em></td>
-<td style="text-align: left;">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
+  <td style="text-align:left"><em>alignment</em></td>
+  <td style="text-align:left">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>bigText</em></td>
-<td style="text-align: left;">Whether to use the bigger font or not.</td>
+  <td style="text-align:left"><em>bigText</em></td>
+  <td style="text-align:left">Whether to use the bigger font or not.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Displays text that goes right from the position</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Displays text that goes right from the position</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">posX</td>
-<td style="text-align: left;">Relative distance from the canvas origin to the left side of the UIelement.</td>
+  <td style="text-align:left">posX</td>
+  <td style="text-align:left">Relative distance from the canvas origin to the left side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">posY</td>
-<td style="text-align: left;">Relative distance from the canvas origin to bottom side of the UIelement.</td>
+  <td style="text-align:left">posY</td>
+  <td style="text-align:left">Relative distance from the canvas origin to bottom side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>text</em></td>
-<td style="text-align: left;">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
+  <td style="text-align:left"><em>text</em></td>
+  <td style="text-align:left">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>bigText</em></td>
-<td style="text-align: left;">Whether to use the bigger font or not.</td>
+  <td style="text-align:left"><em>bigText</em></td>
+  <td style="text-align:left">Whether to use the bigger font or not.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;"><em>text</em></td>
-<td style="text-align: left;">Text to be displayed.</td>
+  <td style="text-align:left"><em>text</em></td>
+  <td style="text-align:left">Text to be displayed.</td>
 </tr>
 <tr>
-<td style="text-align: left;">autoWrap</td>
-<td style="text-align: left;">If true, when the text goes over its width, a linebreak will be inserted.</td>
+  <td style="text-align:left">autoWrap</td>
+  <td style="text-align:left">If true, when the text goes over its width, a linebreak will be inserted.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>alignment</em></td>
-<td style="text-align: left;">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
+  <td style="text-align:left"><em>alignment</em></td>
+  <td style="text-align:left">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>verticalAlignment</em></td>
-<td style="text-align: left;">Vertical alignment, whether the text is aligned to top, center, bottom with the rectangle defined its size.</td>
+  <td style="text-align:left"><em>verticalAlignment</em></td>
+  <td style="text-align:left">Vertical alignment, whether the text is aligned to top, center, bottom with the rectangle defined its size.</td>
 </tr>
 <tr>
-<td style="text-align: left;">bumpBehav</td>
-<td style="text-align: left;"><code>null</code> by default. Setting this to other bumpBehaviour will synchronize highlighting. Creating new BumpBehaviour with this label turns itself reactive.</td>
+  <td style="text-align:left">bumpBehav</td>
+  <td style="text-align:left"><code>null</code> by default. Setting this to other bumpBehaviour will synchronize highlighting. Creating new BumpBehaviour with this label turns itself reactive.</td>
 </tr>
 <tr>
-<td style="text-align: left;">color</td>
-<td style="text-align: left;">Colour of the text.</td>
+  <td style="text-align:left">color</td>
+  <td style="text-align:left">Colour of the text.</td>
 </tr>
 </tbody>
 </table>
-<h4 id="oplabellong">OpLabelLong</h4>
+<h4>OpLabelLong</h4>
 <p>A child class of <a href="###OpLabel"><code>OpLabel</code></a> that is specialized for displaying a long wall of text.
 This will always use the smaller font.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">size</td>
-<td style="text-align: left;">Width and height of the rectangle this UIelement occupies.</td>
+  <td style="text-align:left">size</td>
+  <td style="text-align:left">Width and height of the rectangle this UIelement occupies.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>text</em></td>
-<td style="text-align: left;">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
+  <td style="text-align:left"><em>text</em></td>
+  <td style="text-align:left">Text to be displayed. Setting it empty will generate Lorem Ipsum for testing.</td>
 </tr>
 <tr>
-<td style="text-align: left;">autoWrap</td>
-<td style="text-align: left;">If true, when the text goes over its width, a linebreak will be inserted.</td>
+  <td style="text-align:left">autoWrap</td>
+  <td style="text-align:left">If true, when the text goes over its width, a linebreak will be inserted.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>alignment</em></td>
-<td style="text-align: left;">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
+  <td style="text-align:left"><em>alignment</em></td>
+  <td style="text-align:left">Horizontal alignment, whether the text is aligned to left, center, right with the rectangle defined its size.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">allowOverflow</td>
-<td style="text-align: left;">If it's false, text that goes over the height will be discarded.</td>
+  <td style="text-align:left">allowOverflow</td>
+  <td style="text-align:left">If it's false, text that goes over the height will be discarded.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="oprect">OpRect</h3>
+<h3>OpRect</h3>
 <p><img src="../../../assets/configmachine/provided/Rect.png" alt="OpRect Sample" /></p>
 <p>Simple rectangular, useful to make a boundary to group UIelements.
 Z-order is the order they're initialized, so for that purpose, initialize OpRect beforehand.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">size</td>
-<td style="text-align: left;">Width and height of the rectangle this UIelement occupies.</td>
+  <td style="text-align:left">size</td>
+  <td style="text-align:left">Width and height of the rectangle this UIelement occupies.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>alpha</em></td>
-<td style="text-align: left;">Alpha of the background of the rectangle.</td>
+  <td style="text-align:left"><em>alpha</em></td>
+  <td style="text-align:left">Alpha of the background of the rectangle.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">colorEdge</td>
-<td style="text-align: left;">The colour of boundary sprites.</td>
+  <td style="text-align:left">colorEdge</td>
+  <td style="text-align:left">The colour of boundary sprites.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorFill</td>
-<td style="text-align: left;">The colour of fill sprites.</td>
+  <td style="text-align:left">colorFill</td>
+  <td style="text-align:left">The colour of fill sprites.</td>
 </tr>
 <tr>
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">Alpha of the background of the rectangle. If doesBump, this gets ignored.</td>
+  <td style="text-align:left">alpha</td>
+  <td style="text-align:left">Alpha of the background of the rectangle. If doesBump, this gets ignored.</td>
 </tr>
 <tr>
-<td style="text-align: left;">doesBump</td>
-<td style="text-align: left;">If true, this rectangle reacts to mouse cursor hovering .</td>
+  <td style="text-align:left">doesBump</td>
+  <td style="text-align:left">If true, this rectangle reacts to mouse cursor hovering .</td>
 </tr>
 <tr>
-<td style="text-align: left;">bumpBehav</td>
-<td style="text-align: left;">If doesBump, this controls reaction. If not, this stays <code>null</code>.</td>
+  <td style="text-align:left">bumpBehav</td>
+  <td style="text-align:left">If doesBump, this controls reaction. If not, this stays <code>null</code>.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opimage">OpImage</h3>
+<h3>OpImage</h3>
 <p><img src="../../../assets/configmachine/provided/Image.png" alt="OpImage Sample" /></p>
 <p>Displays an image, whether it's <code>FAtlasElement</code> that's already loaded in <code>Futile.atlasManager</code>, or <code>Texture2D</code>.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Displays Texture2D</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Displays Texture2D</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">image</td>
-<td style="text-align: left;">Texture2D image to be displayed.</td>
+  <td style="text-align:left">image</td>
+  <td style="text-align:left">Texture2D image to be displayed.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Displays FAtlasElement</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Displays FAtlasElement</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">fAtlasElement</td>
-<td style="text-align: left;">The name of FAtlasElement.</td>
+  <td style="text-align:left">fAtlasElement</td>
+  <td style="text-align:left">The name of FAtlasElement.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;"><em>color</em></td>
-<td style="text-align: left;">The colour of the sprite.</td>
+  <td style="text-align:left"><em>color</em></td>
+  <td style="text-align:left">The colour of the sprite.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>anchor</em></td>
-<td style="text-align: left;">The anchor of the sprite. (0f, 0f) to set pos as BottomLeft, and (0.5f, 0.5f) to set pos as the centre.</td>
+  <td style="text-align:left"><em>anchor</em></td>
+  <td style="text-align:left">The anchor of the sprite. (0f, 0f) to set pos as BottomLeft, and (0.5f, 0.5f) to set pos as the centre.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>scale</em></td>
-<td style="text-align: left;">The scale of the sprite.</td>
+  <td style="text-align:left"><em>scale</em></td>
+  <td style="text-align:left">The scale of the sprite.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>alpha</em></td>
-<td style="text-align: left;">The alpha of the sprite.</td>
+  <td style="text-align:left"><em>alpha</em></td>
+  <td style="text-align:left">The alpha of the sprite.</td>
 </tr>
 </tbody>
 </table>
@@ -452,56 +448,56 @@ However, you cannot change the Texture2D version to FAtlasElement and vice versa
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">ChangeImage(newImage)</td>
-<td style="text-align: left;">Swap image to new Texture2D.</td>
+  <td style="text-align:left">ChangeImage(newImage)</td>
+  <td style="text-align:left">Swap image to new Texture2D.</td>
 </tr>
 <tr>
-<td style="text-align: left;">ChangeElement(newElement)</td>
-<td style="text-align: left;">Swap FAtlasElement to new one.</td>
+  <td style="text-align:left">ChangeElement(newElement)</td>
+  <td style="text-align:left">Swap FAtlasElement to new one.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opscrollbox">OpScrollBox</h3>
+<h3>OpScrollBox</h3>
 <p>OpScrollBox is written by Slime_Cubed.
 It's a special UIelement that acts as a canvas, like OpTab.</p>
 <p><img src="../../../assets/configmachine/provided/ScrollBox_Box.png" alt="OpScrollBox Sample - Box" /></p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Rectangular ScrollBox inside OpTab</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Rectangular ScrollBox inside OpTab</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">size</td>
-<td style="text-align: left;">The size of the display.</td>
+  <td style="text-align:left">size</td>
+  <td style="text-align:left">The size of the display.</td>
 </tr>
 <tr>
-<td style="text-align: left;">contentSize</td>
-<td style="text-align: left;">Internal length of the scroll direction.</td>
+  <td style="text-align:left">contentSize</td>
+  <td style="text-align:left">Internal length of the scroll direction.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>horizontal</em></td>
-<td style="text-align: left;">Whether this scrolls horizontally or vertically.</td>
+  <td style="text-align:left"><em>horizontal</em></td>
+  <td style="text-align:left">Whether this scrolls horizontally or vertically.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>hasBack</em></td>
-<td style="text-align: left;">Whether its boundary will have filled backdrop or not.</td>
+  <td style="text-align:left"><em>hasBack</em></td>
+  <td style="text-align:left">Whether its boundary will have filled backdrop or not.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>hasSlideBar</em></td>
-<td style="text-align: left;">Whether this will have a scrollbar or not.</td>
+  <td style="text-align:left"><em>hasSlideBar</em></td>
+  <td style="text-align:left">Whether this will have a scrollbar or not.</td>
 </tr>
 </tbody>
 </table>
@@ -509,26 +505,26 @@ It's a special UIelement that acts as a canvas, like OpTab.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">ScrollBox that replaces OpTab</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">ScrollBox that replaces OpTab</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">tab</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">tab</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">contentSize</td>
-<td style="text-align: left;">The size of the display.</td>
+  <td style="text-align:left">contentSize</td>
+  <td style="text-align:left">The size of the display.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>horizontal</em></td>
-<td style="text-align: left;">Whether this scrolls horizontally or vertically.</td>
+  <td style="text-align:left"><em>horizontal</em></td>
+  <td style="text-align:left">Whether this scrolls horizontally or vertically.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>hasSlideBar</em></td>
-<td style="text-align: left;">Whether this will have a scrollbar or not.</td>
+  <td style="text-align:left"><em>hasSlideBar</em></td>
+  <td style="text-align:left">Whether this will have a scrollbar or not.</td>
 </tr>
 </tbody>
 </table>
@@ -549,119 +545,119 @@ scb.AddItems(new OpLabelLong(new Vector2(20f, 20f), new Vector2(120f, 200f)),
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">redrawFlags</td>
-<td style="text-align: left;">When this ScrollBox should be redrawn. Never / Always(default) / OnHover / OnKeypress.</td>
+  <td style="text-align:left">redrawFlags</td>
+  <td style="text-align:left">When this ScrollBox should be redrawn. Never / Always(default) / OnHover / OnKeypress.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorEdge</td>
-<td style="text-align: left;">Edge colour of rectangles.</td>
+  <td style="text-align:left">colorEdge</td>
+  <td style="text-align:left">Edge colour of rectangles.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorFill</td>
-<td style="text-align: left;">Fill colour of rectangles.</td>
+  <td style="text-align:left">colorFill</td>
+  <td style="text-align:left">Fill colour of rectangles.</td>
 </tr>
 <tr>
-<td style="text-align: left;">fillAlpha</td>
-<td style="text-align: left;">Fill alpha of boundary rectangle.</td>
+  <td style="text-align:left">fillAlpha</td>
+  <td style="text-align:left">Fill alpha of boundary rectangle.</td>
 </tr>
 <tr>
-<td style="text-align: left;">doesBackBump</td>
-<td style="text-align: left;">If false, the boundary rectangle does not react with mouseover.</td>
+  <td style="text-align:left">doesBackBump</td>
+  <td style="text-align:left">If false, the boundary rectangle does not react with mouseover.</td>
 </tr>
 <tr>
-<td style="text-align: left;">ScrollLocked</td>
-<td style="text-align: left;">Whether the scrolling is locked. Manipulated by <code>Lock</code> and <code>Unlock</code> method.</td>
+  <td style="text-align:left">ScrollLocked</td>
+  <td style="text-align:left">Whether the scrolling is locked. Manipulated by <code>Lock</code> and <code>Unlock</code> method.</td>
 </tr>
 <tr>
-<td style="text-align: left;">ScrollOffset</td>
-<td style="text-align: left;">The visual offset, in pixels, of the contents of this ScrollBox. (&lt;=0)</td>
+  <td style="text-align:left">ScrollOffset</td>
+  <td style="text-align:left">The visual offset, in pixels, of the contents of this ScrollBox. (&lt;=0)</td>
 </tr>
 <tr>
-<td style="text-align: left;">MaxScroll</td>
-<td style="text-align: left;">The value of <code>ScrollOffset</code> at the topmost or rightmost position of the box. (&lt;=0)</td>
+  <td style="text-align:left">MaxScroll</td>
+  <td style="text-align:left">The value of <code>ScrollOffset</code> at the topmost or rightmost position of the box. (&lt;=0)</td>
 </tr>
 <tr>
-<td style="text-align: left;">targetScrollOffset</td>
-<td style="text-align: left;">The target value of <code>ScrollOffset</code>. Change this to smoothly animate scrolling.</td>
+  <td style="text-align:left">targetScrollOffset</td>
+  <td style="text-align:left">The target value of <code>ScrollOffset</code>. Change this to smoothly animate scrolling.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">AddItems(items)</td>
-<td style="text-align: left;">Adds a collection of items to the interior of this ScrollBox. Use this instead of <code>OpTab.AddItems</code> for its children.</td>
+  <td style="text-align:left">AddItems(items)</td>
+  <td style="text-align:left">Adds a collection of items to the interior of this ScrollBox. Use this instead of <code>OpTab.AddItems</code> for its children.</td>
 </tr>
 <tr>
-<td style="text-align: left;">Lock(stopImmediately)</td>
-<td style="text-align: left;">Locks scrolling. If <code>stopImmediately</code>, ignore <code>targetScrollOffset</code> and stops immediately.</td>
+  <td style="text-align:left">Lock(stopImmediately)</td>
+  <td style="text-align:left">Locks scrolling. If <code>stopImmediately</code>, ignore <code>targetScrollOffset</code> and stops immediately.</td>
 </tr>
 <tr>
-<td style="text-align: left;">UnLock()</td>
-<td style="text-align: left;">Unlocks scrolling.</td>
+  <td style="text-align:left">UnLock()</td>
+  <td style="text-align:left">Unlocks scrolling.</td>
 </tr>
 <tr>
-<td style="text-align: left;">ScrollToTop(<em>immediate</em>)</td>
-<td style="text-align: left;">Scrolls to the top/leftmost. If <code>immediate</code>, scrolling animation gets cancelled.</td>
+  <td style="text-align:left">ScrollToTop(<em>immediate</em>)</td>
+  <td style="text-align:left">Scrolls to the top/leftmost. If <code>immediate</code>, scrolling animation gets cancelled.</td>
 </tr>
 <tr>
-<td style="text-align: left;">ScrollToBottom(<em>immediate</em>)</td>
-<td style="text-align: left;">Scrolls to the bottom/rightmost. If <code>immediate</code>, scrolling animation gets cancelled.</td>
+  <td style="text-align:left">ScrollToBottom(<em>immediate</em>)</td>
+  <td style="text-align:left">Scrolls to the bottom/rightmost. If <code>immediate</code>, scrolling animation gets cancelled.</td>
 </tr>
 <tr>
-<td style="text-align: left;">MarkDirty()</td>
-<td style="text-align: left;">Forces redrawing at the end of this frame.</td>
+  <td style="text-align:left">MarkDirty()</td>
+  <td style="text-align:left">Forces redrawing at the end of this frame.</td>
 </tr>
 <tr>
-<td style="text-align: left;">MarkDirty(time)</td>
-<td style="text-align: left;">Forces redrawing for the amount of <code>time</code> in seconds.</td>
+  <td style="text-align:left">MarkDirty(time)</td>
+  <td style="text-align:left">Forces redrawing for the amount of <code>time</code> in seconds.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opcontainer">OpContainer</h3>
+<h3>OpContainer</h3>
 <p>This is an easy-to-access FContainer for ConfigMenu.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">The origin of this element relative to the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">The origin of this element relative to the canvas origin.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">container</td>
-<td style="text-align: left;">Accessible FContainer. You can access this without checking isOptionMenu. (NullRef-proof)</td>
+  <td style="text-align:left">container</td>
+  <td style="text-align:left">Accessible FContainer. You can access this without checking isOptionMenu. (NullRef-proof)</td>
 </tr>
 </tbody>
 </table>
 <hr />
-<h2 id="uiconfig">UIconfig</h2>
+<h2>UIconfig</h2>
 <p><code>UIconfig</code> is a subcategory of <a href="##UIelement">UIelement</a>, and has few extra properties and methods.
 Their value gets saved in <code>ModConfigs</code> folder in json format.
 If the key is either <code>null</code>, Empty, or starts with <code>_</code>,
@@ -670,44 +666,44 @@ it is considered <code>cosmetic</code> and its value won't be saved.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">(readonly) Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">(readonly) Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>value</em></td>
-<td style="text-align: left;">The value that gets saved. <code>valueInt</code>, <code>valueFloat</code>, and <code>valueBool</code> exist which is useful for designing reactive GUI.</td>
+  <td style="text-align:left"><em>value</em></td>
+  <td style="text-align:left">The value that gets saved. <code>valueInt</code>, <code>valueFloat</code>, and <code>valueBool</code> exist which is useful for designing reactive GUI.</td>
 </tr>
 <tr>
-<td style="text-align: left;">greyedOut</td>
-<td style="text-align: left;">If true, the element gets greyed out visually and cannot be interacted with.</td>
+  <td style="text-align:left">greyedOut</td>
+  <td style="text-align:left">If true, the element gets greyed out visually and cannot be interacted with.</td>
 </tr>
 <tr>
-<td style="text-align: left;">bumpBehav</td>
-<td style="text-align: left;"><code>BumpBehaviour</code> instance this UIconfig has.</td>
+  <td style="text-align:left">bumpBehav</td>
+  <td style="text-align:left"><code>BumpBehaviour</code> instance this UIconfig has.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">ForceValue(newValue)</td>
-<td style="text-align: left;">Change <code>value</code> without invoking <code>OnChange()</code>.</td>
+  <td style="text-align:left">ForceValue(newValue)</td>
+  <td style="text-align:left">Change <code>value</code> without invoking <code>OnChange()</code>.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opcheckbox">OpCheckBox</h3>
+<h3>OpCheckBox</h3>
 <p><img src="../../../assets/configmachine/provided/CheckBox.png" alt="OpCheckBox Sample" /></p>
 <p><a href="https://en.wikipedia.org/wiki/Checkbox">CheckBox</a> (a.k.a. TickBox) permits the user to make a binary choice.
 This returns bool (<code>&quot;true&quot;</code> or <code>&quot;false&quot;</code>).
@@ -715,70 +711,70 @@ Its size is fixed to 24x24.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Default constructor</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Default constructor</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultBool</em></td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left"><em>defaultBool</em></td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Lazier version that accepts two float for pos</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Lazier version that accepts two float for pos</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">posX</td>
-<td style="text-align: left;">Relative distance from the canvas origin to the left side of the UIelement.</td>
+  <td style="text-align:left">posX</td>
+  <td style="text-align:left">Relative distance from the canvas origin to the left side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">posY</td>
-<td style="text-align: left;">Relative distance from the canvas origin to bottom side of the UIelement.</td>
+  <td style="text-align:left">posY</td>
+  <td style="text-align:left">Relative distance from the canvas origin to bottom side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;">defaultBool</td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left">defaultBool</td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">colorEdge</td>
-<td style="text-align: left;">The colour of its boundary and its symbol.</td>
+  <td style="text-align:left">colorEdge</td>
+  <td style="text-align:left">The colour of its boundary and its symbol.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorFill</td>
-<td style="text-align: left;">The colour that fills inside.</td>
+  <td style="text-align:left">colorFill</td>
+  <td style="text-align:left">The colour that fills inside.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opradiobuttongroup">OpRadioButtonGroup</h3>
+<h3>OpRadioButtonGroup</h3>
 <p><img src="../../../assets/configmachine/provided/RadioButton.png" alt="OpRadioButton Sample" /></p>
 <p><a href="https://en.wikipedia.org/wiki/Radio_button">RadioButton</a> (a.k.a. OptionButton) permits the user to choose only one of a predefined set of mutually exclusive options.
 <code>OpRadioButton</code> is <em>UIelement</em> that <em>looks</em> like an UIconfig, but isn't.
@@ -789,62 +785,62 @@ However, if your OpRadioButtons should be in OpScrollBox, add OpRadioButtonGroup
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Default constructor</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Default constructor</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultValue</em></td>
-<td style="text-align: left;">Default value. 0 or higher.</td>
+  <td style="text-align:left"><em>defaultValue</em></td>
+  <td style="text-align:left">Default value. 0 or higher.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">buttons</td>
-<td style="text-align: left;">OpRadioButtons that belong to this. Use SetButtons(buttons) to set.</td>
+  <td style="text-align:left">buttons</td>
+  <td style="text-align:left">OpRadioButtons that belong to this. Use SetButtons(buttons) to set.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Method</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Method</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">SetButtons(buttons)</td>
-<td style="text-align: left;">Binds OpRadioButton to this. This also adds <code>OpRadioButton</code>s to the canvas this is in.</td>
+  <td style="text-align:left">SetButtons(buttons)</td>
+  <td style="text-align:left">Binds OpRadioButton to this. This also adds <code>OpRadioButton</code>s to the canvas this is in.</td>
 </tr>
 <tr>
-<td style="text-align: left;">Hide()</td>
-<td style="text-align: left;">Calls Hide() for all children.</td>
+  <td style="text-align:left">Hide()</td>
+  <td style="text-align:left">Calls Hide() for all children.</td>
 </tr>
 <tr>
-<td style="text-align: left;">Show()</td>
-<td style="text-align: left;">Calls Show() for all children.</td>
+  <td style="text-align:left">Show()</td>
+  <td style="text-align:left">Calls Show() for all children.</td>
 </tr>
 <tr>
-<td style="text-align: left;">SetColorEdge(newColor)</td>
-<td style="text-align: left;">Changes colorEdge of all children.</td>
+  <td style="text-align:left">SetColorEdge(newColor)</td>
+  <td style="text-align:left">Changes colorEdge of all children.</td>
 </tr>
 <tr>
-<td style="text-align: left;">SetColorFill(newColor)</td>
-<td style="text-align: left;">Changes colorFill of all children.</td>
+  <td style="text-align:left">SetColorFill(newColor)</td>
+  <td style="text-align:left">Changes colorFill of all children.</td>
 </tr>
 </tbody>
 </table>
@@ -855,38 +851,38 @@ group.SetButtons(new OpRadioButton[] {
     new OpRadioButton(300f, 450f), new OpRadioButton(350f, 450f) });
 // SetButtons adds params to the canvas the group is in, so no need to call AddItems again.
 </code></pre>
-<h4 id="opradiobutton">OpRadioButton</h4>
+<h4>OpRadioButton</h4>
 <p>This is an UIelement and it alone does not do anything.
 Its size is fixed to 24x24.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Default constructor</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Default constructor</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Lazier version that accepts two float for pos</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Lazier version that accepts two float for pos</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">posX</td>
-<td style="text-align: left;">Relative distance from the canvas origin to the left side of the UIelement.</td>
+  <td style="text-align:left">posX</td>
+  <td style="text-align:left">Relative distance from the canvas origin to the left side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">posY</td>
-<td style="text-align: left;">Relative distance from the canvas origin to bottom side of the UIelement.</td>
+  <td style="text-align:left">posY</td>
+  <td style="text-align:left">Relative distance from the canvas origin to bottom side of the UIelement.</td>
 </tr>
 </tbody>
 </table>
@@ -894,34 +890,34 @@ Its size is fixed to 24x24.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">greyedOut</td>
-<td style="text-align: left;">If true, locks interaction with this button. The users still can interact with other OpRadioButton in the group.</td>
+  <td style="text-align:left">greyedOut</td>
+  <td style="text-align:left">If true, locks interaction with this button. The users still can interact with other OpRadioButton in the group.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorEdge</td>
-<td style="text-align: left;">The colour of its boundary and its symbol.</td>
+  <td style="text-align:left">colorEdge</td>
+  <td style="text-align:left">The colour of its boundary and its symbol.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorFill</td>
-<td style="text-align: left;">The colour that fills inside.</td>
+  <td style="text-align:left">colorFill</td>
+  <td style="text-align:left">The colour that fills inside.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>value</em></td>
-<td style="text-align: left;">The value of this, although this doesn't get saved. <em>valueBool</em> returns this in bool.</td>
+  <td style="text-align:left"><em>value</em></td>
+  <td style="text-align:left">The value of this, although this doesn't get saved. <em>valueBool</em> returns this in bool.</td>
 </tr>
 <tr>
-<td style="text-align: left;">bumpBehav</td>
-<td style="text-align: left;">BumpBehaviour instance that's bound to this.</td>
+  <td style="text-align:left">bumpBehav</td>
+  <td style="text-align:left">BumpBehaviour instance that's bound to this.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opdragger">OpDragger</h3>
+<h3>OpDragger</h3>
 <p><img src="../../../assets/configmachine/provided/Dragger.png" alt="OpDragger Sample" /></p>
 <p>Rain World Dragger is a small box with a number, which the users can adjust by holding the mouse and move vertically.
 It is useful for cramping adjustable int value in a tight space.
@@ -930,82 +926,82 @@ Its size is fixed to 24x24.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Default constructor</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Default constructor</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultInt</em></td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left"><em>defaultInt</em></td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Lazier version that accepts two float for pos</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Lazier version that accepts two float for pos</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">posX</td>
-<td style="text-align: left;">Relative distance from the canvas origin to the left side of the UIelement.</td>
+  <td style="text-align:left">posX</td>
+  <td style="text-align:left">Relative distance from the canvas origin to the left side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">posY</td>
-<td style="text-align: left;">Relative distance from the canvas origin to bottom side of the UIelement.</td>
+  <td style="text-align:left">posY</td>
+  <td style="text-align:left">Relative distance from the canvas origin to bottom side of the UIelement.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultInt</em></td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left"><em>defaultInt</em></td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Property</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Property</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">min</td>
-<td style="text-align: left;">The minimum number this dragger is allowed to go. (default: 0)</td>
+  <td style="text-align:left">min</td>
+  <td style="text-align:left">The minimum number this dragger is allowed to go. (default: 0)</td>
 </tr>
 <tr>
-<td style="text-align: left;">max</td>
-<td style="text-align: left;">The maximum number this dragger is allowed to go. (default: 99)</td>
+  <td style="text-align:left">max</td>
+  <td style="text-align:left">The maximum number this dragger is allowed to go. (default: 99)</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorEdge</td>
-<td style="text-align: left;">The colour of its boundary.</td>
+  <td style="text-align:left">colorEdge</td>
+  <td style="text-align:left">The colour of its boundary.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorFill</td>
-<td style="text-align: left;">The colour that fills inside.</td>
+  <td style="text-align:left">colorFill</td>
+  <td style="text-align:left">The colour that fills inside.</td>
 </tr>
 <tr>
-<td style="text-align: left;">colorText</td>
-<td style="text-align: left;">The colour of its number inside.</td>
+  <td style="text-align:left">colorText</td>
+  <td style="text-align:left">The colour of its number inside.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="opslider">OpSlider</h3>
+<h3>OpSlider</h3>
 <p><img src="../../../assets/configmachine/provided/Slider.png" alt="OpSlider Sample" /></p>
 <p><a href="https://en.wikipedia.org/wiki/Slider_(computing)">Slider</a> (a.k.a. TrackBar) allows the users to set value by dragging the indicator.
 Clicking a point on the slider also works.
@@ -1014,155 +1010,154 @@ The width perpendicular to its length is fixed to 30.</p>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Default constructor.</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Default constructor.</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;">range</td>
-<td style="text-align: left;">Inclusive range of value.</td>
+  <td style="text-align:left">range</td>
+  <td style="text-align:left">Inclusive range of value.</td>
 </tr>
 <tr>
-<td style="text-align: left;">length</td>
-<td style="text-align: left;">The length of this element.</td>
+  <td style="text-align:left">length</td>
+  <td style="text-align:left">The length of this element.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>vertical</em></td>
-<td style="text-align: left;"></td>
+  <td style="text-align:left"><em>vertical</em></td>
+  <td style="text-align:left"></td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultValue</em></td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left"><em>defaultValue</em></td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Constructor Parameter</th>
-<th style="text-align: left;">Length = range * multi</th>
+  <th style="text-align:left">Constructor Parameter</th>
+  <th style="text-align:left">Length = range * multi</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;">pos</td>
-<td style="text-align: left;">BottomLeft position relative from the canvas origin.</td>
+  <td style="text-align:left">pos</td>
+  <td style="text-align:left">BottomLeft position relative from the canvas origin.</td>
 </tr>
 <tr>
-<td style="text-align: left;">key</td>
-<td style="text-align: left;">Unique key to save and access the value.</td>
+  <td style="text-align:left">key</td>
+  <td style="text-align:left">Unique key to save and access the value.</td>
 </tr>
 <tr>
-<td style="text-align: left;">range</td>
-<td style="text-align: left;"></td>
+  <td style="text-align:left">range</td>
+  <td style="text-align:left"></td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>multi</em></td>
-<td style="text-align: left;">How much pixels length each tick would take.</td>
+  <td style="text-align:left"><em>multi</em></td>
+  <td style="text-align:left">How much pixels length each tick would take.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>vertical</em></td>
-<td style="text-align: left;"></td>
+  <td style="text-align:left"><em>vertical</em></td>
+  <td style="text-align:left"></td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>defaultValue</em></td>
-<td style="text-align: left;">Default value.</td>
+  <td style="text-align:left"><em>defaultValue</em></td>
+  <td style="text-align:left">Default value.</td>
 </tr>
 </tbody>
 </table>
-<h4 id="opslidersubtle">OpSliderSubtle</h4>
+<h4>OpSliderSubtle</h4>
 <p><img src="../../../assets/configmachine/provided/SliderSubtle.png" alt="OpSliderSubtle Sample" /></p>
-<h3 id="opkeybinder">OpKeyBinder</h3>
-<h3 id="opcombobox">OpComboBox</h3>
+<h3>OpKeyBinder</h3>
+<h3>OpComboBox</h3>
 <p><img src="../../../assets/configmachine/provided/ComboBox.png" alt="OpComboBox Sample" /></p>
 <p><a href="https://en.wikipedia.org/wiki/Combo_box">ComboBox</a> is a combination of <a href="https://en.wikipedia.org/wiki/Drop-down_list">Drop-down List</a> and SearchBox.</p>
-<h4 id="opresourceselector">OpResourceSelector</h4>
-<h4 id="listitem">ListItem</h4>
+<h4>OpResourceSelector</h4>
+<h4>ListItem</h4>
 <p>While this technically belongs to <a href="##Custom-Classes">Custom Classes</a>,
 this is currently only used in <code>OpComboBox</code> so it will be included here.</p>
-<h3 id="opcolorpicker">OpColorPicker</h3>
+<h3>OpColorPicker</h3>
 <p><img src="../../../assets/configmachine/provided/ColorPicker.png" alt="OpColorPicker Sample" /></p>
 <p><a href="https://en.wikipedia.org/wiki/Color_picker">ColorPicker</a> (a.k.a. ColorChooser) allows the users to select a Color.
 OpColorPicker has four modes of selecting Color:
 RGB(Red/Green/Blue), HSL(Hue/Satuation/Lightness), PLT(Palette), and HEX (which can be copied and pasted from Clipboard).
 OpColorPicker stores value in HEX, so <code>OpColorPicker.HexToColor</code> method comes handy converting that.</p>
-<h3 id="optextbox">OpTextBox</h3>
+<h3>OpTextBox</h3>
 <p><a href="https://en.wikipedia.org/wiki/Text_box">TextBox</a> (a.k.a. TextField or TextEntryBox) allows the users to input text information.</p>
 <hr />
-<h2 id="uitrigger">UItrigger</h2>
-<h3 id="opsimplebutton">OpSimpleButton</h3>
+<h2>UItrigger</h2>
+<h3>OpSimpleButton</h3>
 <p>SimpleButton is a <a href="https://en.wikipedia.org/wiki/Button_(computing)">PushButton</a> that allows the users to trigger an event.</p>
-<h4 id="opsimpleimagebutton">OpSimpleImageButton</h4>
-<h3 id="opholdbutton">OpHoldButton</h3>
+<h4>OpSimpleImageButton</h4>
+<h3>OpHoldButton</h3>
 <p><img src="../../../assets/configmachine/provided/HoldButton.png" alt="OpHoldButton Sample" /></p>
 <hr />
-<h2 id="custom-classes">Custom Classes</h2>
-<h3 id="dyeablerect">DyeableRect</h3>
-<h3 id="bumpbehaviour">BumpBehaviour</h3>
-<h3 id="ftexture">FTexture</h3>
-<h3 id="fcursor">FCursor</h3>
-<h3 id="labeltest">LabelTest</h3>
-<h3 id="loremipsum">LoremIpsum</h3>
+<h2>Custom Classes</h2>
+<h3>DyeableRect</h3>
+<h3>BumpBehaviour</h3>
+<h3>FTexture</h3>
+<h3>FCursor</h3>
+<h3>LabelTest</h3>
+<h3>LoremIpsum</h3>
 <table>
 <thead>
 <tr>
-<th style="text-align: left;">Properties</th>
-<th style="text-align: left;"></th>
+  <th style="text-align:left">Properties</th>
+  <th style="text-align:left"></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align: left;"><em>_init</em></td>
-<td style="text-align: left;">Whether this is initialized in ConfigMenu or not. The same as <code>OptionInterface.isOptionMenu</code>.</td>
+  <td style="text-align:left"><em>_init</em></td>
+  <td style="text-align:left">Whether this is initialized in ConfigMenu or not. The same as <code>OptionInterface.isOptionMenu</code>.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>menu</em></td>
-<td style="text-align: left;">Rain World Menu instance this element is belong to.</td>
+  <td style="text-align:left"><em>menu</em></td>
+  <td style="text-align:left">Rain World Menu instance this element is belong to.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>owner</em></td>
-<td style="text-align: left;">Rain World Page instance this element is belong to.</td>
+  <td style="text-align:left"><em>owner</em></td>
+  <td style="text-align:left">Rain World Page instance this element is belong to.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>tab</em></td>
-<td style="text-align: left;">OpTab instance this element is in.</td>
+  <td style="text-align:left"><em>tab</em></td>
+  <td style="text-align:left">OpTab instance this element is in.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>subObjects</em></td>
-<td style="text-align: left;"><code>MenuObject</code> instances this element has.</td>
+  <td style="text-align:left"><em>subObjects</em></td>
+  <td style="text-align:left"><code>MenuObject</code> instances this element has.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>myContainer</em></td>
-<td style="text-align: left;">FContainer that this element has. It gets initialized in constructor <em>only</em> when <code>_init</code>.</td>
+  <td style="text-align:left"><em>myContainer</em></td>
+  <td style="text-align:left">FContainer that this element has. It gets initialized in constructor <em>only</em> when <code>_init</code>.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>isHidden</em></td>
-<td style="text-align: left;">Whether this is hidden and not visible.</td>
+  <td style="text-align:left"><em>isHidden</em></td>
+  <td style="text-align:left">Whether this is hidden and not visible.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>fixedSize</em></td>
-<td style="text-align: left;">If this is not null, this element's size will always be this. (<em>fixedRad</em> does the similar)</td>
+  <td style="text-align:left"><em>fixedSize</em></td>
+  <td style="text-align:left">If this is not null, this element's size will always be this. (<em>fixedRad</em> does the similar)</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>_soundFill</em></td>
-<td style="text-align: left;">Add number (in proportion with sound effect's length) to this whenever you're playing soundeffect.</td>
+  <td style="text-align:left"><em>_soundFill</em></td>
+  <td style="text-align:left">Add number (in proportion with sound effect's length) to this whenever you're playing soundeffect.</td>
 </tr>
 <tr>
-<td style="text-align: left;"><em>_soundFilled</em></td>
-<td style="text-align: left;">If this is true, avoid excuting <code>menu.PlaySound</code></td>
+  <td style="text-align:left"><em>_soundFilled</em></td>
+  <td style="text-align:left">If this is true, avoid excuting <code>menu.PlaySound</code></td>
 </tr>
 </tbody>
 </table>
-
 
 </body>
 </html>

--- a/pages/utility-mods/config-machine/Translation-Support.html
+++ b/pages/utility-mods/config-machine/Translation-Support.html
@@ -1,22 +1,20 @@
-﻿<!DOCTYPE html>
-<html>
+﻿<!doctype html>
+<html lang='en'>
 <head>
-<script src='../../../scripts/extras.js'></script>
-<link rel='stylesheet' href='../../../css/article.css'/>
-<link rel='stylesheet' href='../../../css/main.css'/>
-    <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width initial-scale=1'>
-    <title>Translation Support</title>
+<link rel='stylesheet' href='../../css/main.css'/>
+<link rel='stylesheet' href='../../css/article.css'/>
+<script src='../../scripts/extras.js'></script>
+<meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
+<title>Translation Support (Rain World Modding)</title>
 </head>
 <body>
-
-    <h1 id="translation-support">Translation Support</h1>
+<h1>Translation Support</h1>
 <p>While you can support translation for your mod on your own, Config Machine also offers translation solution.
 If you do not want to make GUI and only want to use Translation feature, check out <a href="GeneratedOI.html">GeneratedOI</a>.</p>
 <hr />
-<h2 id="preparation">Preparation</h2>
-<p><code>OptionInterface</code> has a method called <code>Translate</code>, and when it��s initially called,
-it will load specified(<code>transFile</code>) txt file from your assembly and make Dictionary depending on Rain World��s language setting.
+<h2>Preparation</h2>
+<p><code>OptionInterface</code> has a method called <code>Translate</code>, and when it¡¯s initially called,
+it will load specified(<code>transFile</code>) txt file from your assembly and make Dictionary depending on Rain World¡¯s language setting.
 In <code>BaseUnityPlugin.LoadOI</code> method, store the <code>OptionInterface</code> instance in somewhere before returning it.</p>
 <pre><code class="language-c#">public static MyOI oi;
 public static MyOI LoadOI()
@@ -32,13 +30,13 @@ public static MyOI LoadOI()
 }
 </code></pre>
 <p>Now when you need to translate something, you can pass your string through this method.</p>
-<h2 id="writing-translation-txt">Writing Translation txt</h2>
+<h2>Writing Translation txt</h2>
 <p>Create a txt file that contains translation, too.
 Add txt file to your project, <em>make sure</em> that its encoding is <code>UTF-8</code>,
 then set it to be [Embedded Resources] for its compile setting.
 Then, in the constructor of your OptionInterface, set <code>transFile</code> to that resource name.</p>
-<p>If you have not put it in any folder, it��s usually <code>&lt;ProjectName&gt;.&lt;TxtFileName&gt;.txt</code>, but you might get it wrong.
-If it��s wrong when <code>OptionInterface.Translate</code> is initially called, Config Machine will log all the resources in your assembly in exceptionLog.txt so you can copy from it.</p>
+<p>If you have not put it in any folder, it¡¯s usually <code>&lt;ProjectName&gt;.&lt;TxtFileName&gt;.txt</code>, but you might get it wrong.
+If it¡¯s wrong when <code>OptionInterface.Translate</code> is initially called, Config Machine will log all the resources in your assembly in exceptionLog.txt so you can copy from it.</p>
 <pre><code class="language-c#">public MyOI() : base(plugin: MyPlugin.instance)
 {
     this.transFile = &quot;MyPlugin.Translation.txt&quot;;
@@ -49,41 +47,41 @@ If it��s wrong when <code>OptionInterface.Translate</code> is initially call
 <p>The format of the translation txt file for Config Machine is quite primitive.
 First, you add a keyword, then <code>|</code> for language separator,
 then language ID(<code>eng, ita, ger, spa, por, (kor, jap, rus)</code>), <code>$</code> for another separator, then translation.
-If there is no translation, the translator will return the keyword, unless there is a translation for ��eng��. (In that case, English ��translation�� will be used as default translation)</p>
+If there is no translation, the translator will return the keyword, unless there is a translation for ¡®eng¡¯. (In that case, English ¡®translation¡¯ will be used as default translation)</p>
 <p>The following is formatting example for txt file.</p>
 <pre><code>// If the first two characters are '//', this line will be ignored.
-Nightcat Horn Colour|kor$������ �� ����
+Nightcat Horn Colour|kor$¹ã°í¾çÀÌ »Ô »ö±ò
 // If you have variables, avoid using partial sentences. Not every language has the same subject-verb-object order.
-Press &lt;ThrowKey&gt; to stab.|kor$&lt;ThrowKey&gt; ��ư�� ���� ���.
+Press &lt;ThrowKey&gt; to stab.|kor$&lt;ThrowKey&gt; ¹öÆ°À» ´­·¯ Âî¸£±â.
 // When translating the shorter-phrase, the translation might be sensitive with context, but English one does not. Duplicate key causes error(You can check exceptionLog.txt for duplicates), so you can set 'eng' translation for these cases.
-Property_as of possession|eng$Property|kor$������
-Property_as of quality|eng$Property|kor$�Ӽ�
-// For line-breaks, use \n. (In code, it��d be \\n) Each line represents a phrase, so you can��t use actual line-break in a single chunk.
-LINE\nBREAK|kor$��\n�ٲ�
+Property_as of possession|eng$Property|kor$¼ÒÀ¯¹°
+Property_as of quality|eng$Property|kor$¼Ó¼º
+// For line-breaks, use \n. (In code, it¡¯d be \\n) Each line represents a phrase, so you can¡¯t use actual line-break in a single chunk.
+LINE\nBREAK|kor$ÁÙ\n¹Ù²Þ
 </code></pre>
-<h2 id="running-translation">Running Translation</h2>
+<h2>Running Translation</h2>
 <p>And here are some examples in code.
-Yes, running every text through the <code>Translate</code> method is tedious, but this is usually how it��s done in Rain World or many other games.
+Yes, running every text through the <code>Translate</code> method is tedious, but this is usually how it¡¯s done in Rain World or many other games.
 Make sure to check your mod in another language to confirm you haven't missed any item.</p>
 <pre><code class="language-c#">labelCpkrRadio.text = MyPlugin.Translate(&quot;Nightcat Horn Colour&quot;);
 instance.room.game.cameras[0].hud.textPrompt.AddMessage(MyPlugin.Translate(&quot;Press &lt;ThrowKey&gt; to stab.&quot;).Replace(&quot;&lt;ThrowKey&gt;&quot;, k.ToString())); // k is variable in this example.
 labelLineBreak.text = MyPlugin.Translate(&quot;LINE\\nBREAK&quot;);
 </code></pre>
 <hr />
-<p>These aren��t the part of tutorial but more of tips.
-This does not just apply for making Rain World mods but to general, whenever you��re making something that supports translation.</p>
+<p>These aren¡¯t the part of tutorial but more of tips.
+This does not just apply for making Rain World mods but to general, whenever you¡¯re making something that supports translation.</p>
 <ul>
-<li><p>When you have variables in your sentence, do not use partial phrases and Frankenstein it later with <code>string.Concat</code>.
-Not every language has the same grammar order of subject-verb-object as English.</p>
-</li>
-<li><p>Leave credits to the translators, since you��re most likely getting volunteers from them.
-This is both good for showing gratitude to the translators and keeping the quality of the translation.
-The lack of credits equals a lack of responsibility.</p>
-</li>
-<li><p>Do not use machine translation. That usually hurts the user experience rather than enhancing it.</p>
-</li>
+<li>When you have variables in your sentence, do not use partial phrases and Frankenstein it later with <code>string.Concat</code>.</li>
 </ul>
-
+<p>Not every language has the same grammar order of subject-verb-object as English.</p>
+<ul>
+<li>Leave credits to the translators, since you¡¯re most likely getting volunteers from them.</li>
+</ul>
+<p>This is both good for showing gratitude to the translators and keeping the quality of the translation.
+The lack of credits equals a lack of responsibility.</p>
+<ul>
+<li>Do not use machine translation. That usually hurts the user experience rather than enhancing it.</li>
+</ul>
 
 </body>
 </html>

--- a/pages/utility-mods/config-machine/Translation-Support.html
+++ b/pages/utility-mods/config-machine/Translation-Support.html
@@ -1,9 +1,9 @@
 ﻿<!doctype html>
 <html lang='en'>
 <head>
-<link rel='stylesheet' href='../../css/main.css'/>
-<link rel='stylesheet' href='../../css/article.css'/>
-<script src='../../scripts/extras.js'></script>
+<link rel='stylesheet' href='../../../css/main.css'/>
+<link rel='stylesheet' href='../../../css/article.css'/>
+<script src='../../../scripts/extras.js'></script>
 <meta charset='UTF-8'><meta name='viewport' content='width=device-width initial-scale=1'>
 <title>Translation Support (Rain World Modding)</title>
 </head>


### PR DESCRIPTION
Adds a python script that runs from a GitHub action that generates HTML from markdown files in the `pages` directory and adds external resource links appropriately. 
The mistune library's HTML output has a slightly different format to Typora, so there have been changes to existing pages that are included in this PR ~~I swear this isn't a stunt to boost my GitHub stats~~. As always, feedback is welcome